### PR TITLE
feat(retrieval): add BM25 lexical retriever

### DIFF
--- a/src/retrieval/lexical.py
+++ b/src/retrieval/lexical.py
@@ -1,0 +1,85 @@
+import logging
+import re
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from rank_bm25 import BM25Okapi
+
+try:  # pragma: no cover - optional dependency
+    from nltk.stem import PorterStemmer
+except Exception:  # pragma: no cover
+    PorterStemmer = None  # type: ignore
+
+
+Tokenizer = Callable[[str], List[str]]
+
+
+def default_tokenizer(text: str) -> List[str]:
+    """Simple regex-based tokenizer."""
+    return re.findall(r"\b\w+\b", text.lower())
+
+
+class LexicalBM25:
+    """Lexical retrieval using BM25Okapi with optional stemming."""
+
+    def __init__(
+        self,
+        tokenizer: Optional[Tokenizer] = None,
+        enable_stemming: bool = False,
+    ) -> None:
+        self._logger = logging.getLogger(__name__)
+        self.tokenizer = tokenizer or default_tokenizer
+        self.enable_stemming = enable_stemming and PorterStemmer is not None
+        self.stemmer = PorterStemmer() if self.enable_stemming else None
+        self.documents: List[str] = []
+        self.doc_ids: List[str] = []
+        self.corpus_tokens: List[List[str]] = []
+        self.bm25: Optional[BM25Okapi] = None
+
+        if enable_stemming and PorterStemmer is None:
+            self._logger.warning(
+                "Stemming requested but " "nltk not available; disabling"
+            )
+
+    def _preprocess(self, text: str) -> List[str]:
+        tokens = self.tokenizer(text)
+        if self.stemmer:
+            tokens = [self.stemmer.stem(tok) for tok in tokens]
+        return tokens
+
+    def index_documents(
+        self,
+        documents: List[str],
+    ) -> Tuple[List[str], Dict[str, Any]]:
+        """Add documents to the BM25 index."""
+        try:
+            start = len(self.documents)
+            ids = []
+            for i, doc in enumerate(documents):
+                doc_id = str(start + i)
+                self.documents.append(doc)
+                self.doc_ids.append(doc_id)
+                self.corpus_tokens.append(self._preprocess(doc))
+                ids.append(doc_id)
+            if self.corpus_tokens:
+                self.bm25 = BM25Okapi(self.corpus_tokens)
+            return ids, {"status": "success", "count": len(ids)}
+        except Exception as exc:  # pragma: no cover
+            self._logger.error("Failed to index documents: %s", exc)
+            return [], {"status": "error", "error": str(exc)}
+
+    def query(
+        self, query: str, top_k: int = 5
+    ) -> Tuple[List[Tuple[str, float]], Dict[str, Any]]:
+        """Query the index and return doc IDs with BM25 scores."""
+        try:
+            if not self.bm25:
+                return [], {"status": "empty"}
+            tokens = self._preprocess(query)
+            scores = self.bm25.get_scores(tokens)
+            ranked = sorted(
+                zip(self.doc_ids, scores), key=lambda x: x[1], reverse=True
+            )[:top_k]
+            return ranked, {"retrieved": len(ranked)}
+        except Exception as exc:  # pragma: no cover
+            self._logger.error("BM25 query failed: %s", exc)
+            return [], {"status": "error", "error": str(exc)}

--- a/tests/test_retrieval/conftest.py
+++ b/tests/test_retrieval/conftest.py
@@ -1,0 +1,18 @@
+import sys
+import types
+
+stub = types.ModuleType("sentence_transformers")
+
+
+class SentenceTransformer:  # pragma: no cover - minimal stub
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+def encode(self, *args, **kwargs):  # pragma: no cover
+    return []
+
+
+SentenceTransformer.encode = encode
+stub.SentenceTransformer = SentenceTransformer
+sys.modules.setdefault("sentence_transformers", stub)

--- a/tests/test_retrieval/test_lexical.py
+++ b/tests/test_retrieval/test_lexical.py
@@ -1,0 +1,45 @@
+from src.retrieval.lexical import LexicalBM25
+
+
+def test_index_and_query_returns_scores():
+    retriever = LexicalBM25()
+    ids, meta = retriever.index_documents(
+        [
+            "hello world",
+            "foo bar",
+            "hello there",
+        ]
+    )
+    assert meta["status"] == "success"
+    results, _ = retriever.query("hello")
+    assert any(r[0] in (ids[0], ids[2]) for r in results)
+    assert any(score > 0 for _, score in results)
+
+
+def test_index_update_adds_documents():
+    retriever = LexicalBM25()
+    retriever.index_documents(["first doc"])
+    retriever.index_documents(["second doc", "third doc"])
+    results, _ = retriever.query("third")
+    assert len(retriever.documents) == 3
+    assert results[0][0] == "2"
+
+
+def test_stemming_enables_root_match():
+    retriever = LexicalBM25(enable_stemming=True)
+    retriever.index_documents(
+        [
+            "running fast",
+            "jogging slow",
+            "walk home",
+        ]
+    )
+    results, _ = retriever.query("run")
+    assert results[0][1] > 0
+
+
+def test_without_stemming_no_match():
+    retriever = LexicalBM25()
+    retriever.index_documents(["running fast"])
+    results, _ = retriever.query("run")
+    assert results[0][1] == 0


### PR DESCRIPTION
## Description:
- implement BM25-based lexical retrieval with optional stemming
- allow dynamic index updates and expose score-based query API
- add unit tests and stub for sentence-transformers

## Testing Done:
- `python -m black src/ tests/`
- `python -m flake8 src/ tests/`
- `python -m mypy src/ --ignore-missing-imports`
- `python -m pytest tests/ -v`

## Performance Impact:
- N/A

## Configuration Changes:
- None

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bbc3681aa48322bc4eaa3f20705263