### PR TITLE
feat(retrieval): support hybrid query modes

### DIFF
--- a/src/query_service.py
+++ b/src/query_service.py
@@ -1,0 +1,21 @@
+"""Service layer for executing retrieval queries."""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from src.retrieval.hybrid import HybridRetriever
+
+
+class QueryService:
+    """Runs queries using a HybridRetriever with mode selection."""
+
+    def __init__(
+        self, retriever: HybridRetriever, default_mode: str = "hybrid"
+    ) -> None:
+        self.retriever = retriever
+        self.default_mode = default_mode
+
+    def query(
+        self, query: str, mode: Optional[str] = None, top_k: int = 5
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        retrieval_mode = mode or self.default_mode
+        return self.retriever.query(query, mode=retrieval_mode, top_k=top_k)

--- a/src/retrieval/dense.py
+++ b/src/retrieval/dense.py
@@ -78,6 +78,22 @@ class DenseRetriever:
             self._logger.error("Failed to embed query: %s", exc)
             return [], {"status": "error", "error": str(exc)}
 
+    def query(
+        self, query: str, top_k: int = 5
+    ) -> Tuple[List[Tuple[str, float]], Dict[str, Any]]:
+        """Query the Pinecone index with a text string."""
+        try:
+            embedding, _ = self.embed_query(query)
+            response = self.pinecone_client.query(
+                self.index_name, embedding, top_k=top_k
+            )
+            matches = getattr(response, "matches", [])
+            results = [(m["id"], m["score"]) for m in matches]
+            return results, {"retrieved": len(results)}
+        except Exception as exc:  # pragma: no cover
+            self._logger.error("Dense query failed: %s", exc)
+            return [], {"status": "error", "error": str(exc)}
+
     def validate_index(self) -> Tuple[bool, Dict[str, Any]]:
         """Validate Pinecone index dimension."""
         try:

--- a/src/retrieval/hybrid.py
+++ b/src/retrieval/hybrid.py
@@ -1,0 +1,109 @@
+"""Hybrid retrieval combining dense and lexical methods with RRF fusion."""
+
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict, List, Tuple, cast
+
+from .dense import DenseRetriever
+from .lexical import LexicalBM25
+
+DEFAULT_RRF_K = 60
+
+
+class HybridRetriever:
+    """Orchestrates dense and lexical retrievers with per-query modes."""
+
+    def __init__(
+        self,
+        dense_retriever: DenseRetriever,
+        lexical_retriever: LexicalBM25,
+        default_mode: str = "hybrid",
+    ) -> None:
+        self._logger = logging.getLogger(__name__)
+        self.dense = dense_retriever
+        self.lexical = lexical_retriever
+        self.default_mode = default_mode
+
+    def _rrf_fusion(
+        self,
+        dense_results: List[Tuple[str, float]],
+        lexical_results: List[Tuple[str, float]],
+        k: int,
+        w_dense: float,
+        w_lexical: float,
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        scores: Dict[str, float] = {}
+        component: Dict[str, Dict[str, float]] = {}
+        dense_ids = {doc_id for doc_id, _ in dense_results}
+        lexical_ids = {doc_id for doc_id, _ in lexical_results}
+
+        for rank, (doc_id, score) in enumerate(dense_results, start=1):
+            scores.setdefault(doc_id, 0.0)
+            scores[doc_id] += w_dense * (1.0 / (k + rank))
+            component.setdefault(doc_id, {})["dense"] = score
+        for rank, (doc_id, score) in enumerate(lexical_results, start=1):
+            scores.setdefault(doc_id, 0.0)
+            scores[doc_id] += w_lexical * (1.0 / (k + rank))
+            component.setdefault(doc_id, {})["lexical"] = score
+
+        merged = [
+            {
+                "id": doc_id,
+                "score": score,
+                "source": "+".join(
+                    filter(
+                        None,
+                        [
+                            "dense" if doc_id in dense_ids else "",
+                            "lexical" if doc_id in lexical_ids else "",
+                        ],
+                    )
+                ),
+            }
+            for doc_id, score in scores.items()
+        ]
+        merged.sort(key=lambda x: cast(float, x["score"]), reverse=True)
+        metadata = {
+            "fusion_method": "rrf",
+            "rrf_weights": {"dense": w_dense, "lexical": w_lexical},
+            "component_scores": component,
+        }
+        return merged, metadata
+
+    def query(
+        self,
+        query: str,
+        mode: str | None = None,
+        top_k: int = 5,
+        k: int = DEFAULT_RRF_K,
+        w_dense: float = 1.0,
+        w_lexical: float = 1.0,
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        selected_mode = mode or self.default_mode
+        if selected_mode == "dense":
+            results, meta = self.dense.query(query, top_k=top_k)
+            wrapped = [
+                {"id": doc_id, "score": score, "source": "dense"}
+                for doc_id, score in results
+            ]
+            meta.update({"retrieval_mode": "dense"})
+            return wrapped, meta
+        if selected_mode == "lexical":
+            results, meta = self.lexical.query(query, top_k=top_k)
+            wrapped = [
+                {"id": doc_id, "score": score, "source": "lexical"}
+                for doc_id, score in results
+            ]
+            meta.update({"retrieval_mode": "lexical"})
+            return wrapped, meta
+
+        with ThreadPoolExecutor() as executor:
+            dense_future = executor.submit(self.dense.query, query, top_k)
+            lexical_future = executor.submit(self.lexical.query, query, top_k)
+            dense_results, _ = dense_future.result()
+            lexical_results, _ = lexical_future.result()
+        merged, meta = self._rrf_fusion(
+            dense_results, lexical_results, k, w_dense, w_lexical
+        )
+        meta.update({"retrieval_mode": "hybrid"})
+        return merged[:top_k], meta

--- a/tests/test_query_service.py
+++ b/tests/test_query_service.py
@@ -1,0 +1,24 @@
+from src.query_service import QueryService
+
+
+class StubHybrid:
+    def __init__(self) -> None:
+        self.last_mode = None
+
+    def query(self, query, mode=None, top_k=5):
+        self.last_mode = mode
+        return [], {}
+
+
+def test_query_service_defaults_to_hybrid():
+    stub = StubHybrid()
+    service = QueryService(stub)
+    service.query("hello")
+    assert stub.last_mode == "hybrid"
+
+
+def test_query_service_mode_override():
+    stub = StubHybrid()
+    service = QueryService(stub)
+    service.query("hello", mode="lexical")
+    assert stub.last_mode == "lexical"

--- a/tests/test_retrieval/test_hybrid.py
+++ b/tests/test_retrieval/test_hybrid.py
@@ -1,0 +1,29 @@
+from src.retrieval.hybrid import HybridRetriever
+
+
+class StubDense:
+    def query(self, query, top_k=5):
+        return [("a", 0.9), ("b", 0.8)], {"retrieved": 2}
+
+
+class StubLexical:
+    def query(self, query, top_k=5):
+        return [("b", 1.0), ("c", 0.5)], {"retrieved": 2}
+
+
+def test_hybrid_rrf_merges_and_tags_sources():
+    hybrid = HybridRetriever(StubDense(), StubLexical())
+    results, meta = hybrid.query("test")
+    assert results[0]["id"] == "b"
+    assert results[0]["source"] == "dense+lexical"
+    assert meta["fusion_method"] == "rrf"
+    assert "rrf_weights" in meta
+    assert "component_scores" in meta
+
+
+def test_mode_selection_dense_and_lexical():
+    hybrid = HybridRetriever(StubDense(), StubLexical())
+    dense_only, _ = hybrid.query("test", mode="dense")
+    assert all(r["source"] == "dense" for r in dense_only)
+    lexical_only, _ = hybrid.query("test", mode="lexical")
+    assert all(r["source"] == "lexical" for r in lexical_only)


### PR DESCRIPTION
## Description:
- orchestrate dense and lexical retrieval in parallel
- add per-query mode selection with RRF fusion
- set hybrid retrieval as default in query service

## Testing Done:
- `black src tests`
- `flake8 src tests` *(fails: command not found)*
- `mypy --ignore-missing-imports src`
- `python -m pytest tests/ -v`

## Performance Impact:
- no performance measurements were taken

## Configuration Changes:
- added optional `mode` parameter to query service, defaulting to `hybrid`

## Evaluation Results:
- not applicable

------
https://chatgpt.com/codex/tasks/task_e_68bc3fc2e7d08322ab390758464c1e28