### PR TITLE
feat(ranking): add RRF fusion utility

### DIFF
--- a/src/ranking/rrf_fusion.py
+++ b/src/ranking/rrf_fusion.py
@@ -1,0 +1,52 @@
+"""Reciprocal Rank Fusion (RRF) utilities."""
+
+from typing import Any, Dict, List, Tuple
+
+DEFAULT_RRF_K = 60
+
+
+def rrf_fusion(
+    results: Dict[str, List[Tuple[str, float]]],
+    *,
+    k: int = DEFAULT_RRF_K,
+    weights: Dict[str, float] | None = None,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Fuse ranked results from multiple retrievers using RRF.
+
+    Args:
+        results: Mapping of retriever name to list of ``(doc_id, score)``
+            tuples ordered by rank (best first).
+        k: RRF ``k`` constant. Defaults to ``DEFAULT_RRF_K``.
+        weights: Optional mapping of retriever name to weight. Any retriever
+            not present defaults to weight ``1.0``.
+
+    Returns:
+        A tuple containing the fused ranking and metadata. The ranking is a
+        list of dictionaries with ``id``, ``score`` and ``source`` fields.
+        Metadata includes ``fusion_method``, ``rrf_weights`` and per-document
+        ``component_scores`` for audit trails.
+    """
+    weights = weights or {}
+    fused_scores: Dict[str, float] = {}
+    component_scores: Dict[str, Dict[str, float]] = {}
+
+    for retriever, docs in results.items():
+        weight = weights.get(retriever, 1.0)
+        for rank, (doc_id, score) in enumerate(docs, start=1):
+            fused_scores.setdefault(doc_id, 0.0)
+            fused_scores[doc_id] += weight * (1.0 / (k + rank))
+            component_scores.setdefault(doc_id, {})[retriever] = score
+
+    merged: List[Dict[str, Any]] = []
+    for doc_id, score in fused_scores.items():
+        sources = "+".join(sorted(component_scores[doc_id].keys()))
+        merged.append({"id": doc_id, "score": score, "source": sources})
+
+    merged.sort(key=lambda x: x["score"], reverse=True)
+
+    metadata = {
+        "fusion_method": "rrf",
+        "rrf_weights": {name: weights.get(name, 1.0) for name in results},
+        "component_scores": component_scores,
+    }
+    return merged, metadata

--- a/src/retrieval/hybrid.py
+++ b/src/retrieval/hybrid.py
@@ -2,12 +2,11 @@
 
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict, List, Tuple, cast
+from typing import Any, Dict, List, Tuple
 
+from ..ranking.rrf_fusion import DEFAULT_RRF_K, rrf_fusion
 from .dense import DenseRetriever
 from .lexical import LexicalBM25
-
-DEFAULT_RRF_K = 60
 
 
 class HybridRetriever:
@@ -23,52 +22,6 @@ class HybridRetriever:
         self.dense = dense_retriever
         self.lexical = lexical_retriever
         self.default_mode = default_mode
-
-    def _rrf_fusion(
-        self,
-        dense_results: List[Tuple[str, float]],
-        lexical_results: List[Tuple[str, float]],
-        k: int,
-        w_dense: float,
-        w_lexical: float,
-    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
-        scores: Dict[str, float] = {}
-        component: Dict[str, Dict[str, float]] = {}
-        dense_ids = {doc_id for doc_id, _ in dense_results}
-        lexical_ids = {doc_id for doc_id, _ in lexical_results}
-
-        for rank, (doc_id, score) in enumerate(dense_results, start=1):
-            scores.setdefault(doc_id, 0.0)
-            scores[doc_id] += w_dense * (1.0 / (k + rank))
-            component.setdefault(doc_id, {})["dense"] = score
-        for rank, (doc_id, score) in enumerate(lexical_results, start=1):
-            scores.setdefault(doc_id, 0.0)
-            scores[doc_id] += w_lexical * (1.0 / (k + rank))
-            component.setdefault(doc_id, {})["lexical"] = score
-
-        merged = [
-            {
-                "id": doc_id,
-                "score": score,
-                "source": "+".join(
-                    filter(
-                        None,
-                        [
-                            "dense" if doc_id in dense_ids else "",
-                            "lexical" if doc_id in lexical_ids else "",
-                        ],
-                    )
-                ),
-            }
-            for doc_id, score in scores.items()
-        ]
-        merged.sort(key=lambda x: cast(float, x["score"]), reverse=True)
-        metadata = {
-            "fusion_method": "rrf",
-            "rrf_weights": {"dense": w_dense, "lexical": w_lexical},
-            "component_scores": component,
-        }
-        return merged, metadata
 
     def query(
         self,
@@ -102,8 +55,10 @@ class HybridRetriever:
             lexical_future = executor.submit(self.lexical.query, query, top_k)
             dense_results, _ = dense_future.result()
             lexical_results, _ = lexical_future.result()
-        merged, meta = self._rrf_fusion(
-            dense_results, lexical_results, k, w_dense, w_lexical
+        merged, meta = rrf_fusion(
+            {"dense": dense_results, "lexical": lexical_results},
+            k=k,
+            weights={"dense": w_dense, "lexical": w_lexical},
         )
         meta.update({"retrieval_mode": "hybrid"})
         return merged[:top_k], meta

--- a/tests/test_ranking/test_rrf.py
+++ b/tests/test_ranking/test_rrf.py
@@ -1,0 +1,27 @@
+import math
+
+from src.ranking.rrf_fusion import DEFAULT_RRF_K, rrf_fusion
+
+
+def test_rrf_scores_and_weights() -> None:
+    dense = [("d1", 0.9), ("d2", 0.8)]
+    lexical = [("d2", 0.7), ("d3", 0.6)]
+
+    fused, meta = rrf_fusion(
+        {"dense": dense, "lexical": lexical},
+        weights={"dense": 2.0, "lexical": 1.0},
+    )
+
+    dense_contrib = 2.0 * (1.0 / (DEFAULT_RRF_K + 2))
+    lexical_contrib = 1.0 * (1.0 / (DEFAULT_RRF_K + 1))
+    expected_d2 = dense_contrib + lexical_contrib
+    expected_d1 = 2.0 * (1.0 / (DEFAULT_RRF_K + 1))
+
+    assert math.isclose(fused[0]["score"], expected_d2)
+    assert fused[0]["id"] == "d2"
+    assert math.isclose(fused[1]["score"], expected_d1)
+    assert fused[1]["id"] == "d1"
+
+    assert meta["fusion_method"] == "rrf"
+    assert meta["rrf_weights"] == {"dense": 2.0, "lexical": 1.0}
+    assert meta["component_scores"]["d2"] == {"dense": 0.8, "lexical": 0.7}


### PR DESCRIPTION
## Description:
- add reusable RRF fusion module with configurable per-retriever weights
- refactor hybrid retriever to use new fusion utility
- include unit test validating weighted fusion and metadata output

## Testing Done:
- `python -m black src/ tests/`
- `python -m flake8 src/ tests/`
- `python -m mypy src/ --ignore-missing-imports`
- `python -m pytest tests/ -v`

## Performance Impact:
- none expected

## Configuration Changes:
- none

## Evaluation Results:
- not applicable

------
https://chatgpt.com/codex/tasks/task_e_68bc40bc4380832292cb1b687b2db8ee