### PR TITLE
feat(ui): add routed gradio app with navbar

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,25 @@
+"""Gradio multipage application with simple routing."""
+
+from fastapi import FastAPI
+from gradio.routes import mount_gradio_app
+
+from src.ui import chat_page, ingest_page, evaluate_page, settings_page
+
+
+def create_app() -> FastAPI:
+    """Create the FastAPI application and mount Gradio routes."""
+    app = FastAPI()
+    mount_gradio_app(app, chat_page(), path="/")
+    mount_gradio_app(app, ingest_page(), path="/ingest")
+    mount_gradio_app(app, evaluate_page(), path="/evaluate")
+    mount_gradio_app(app, settings_page(), path="/settings")
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=7860)

--- a/src/ui/__init__.py
+++ b/src/ui/__init__.py
@@ -1,0 +1,15 @@
+"""User interface pages for the Gradio application."""
+
+from .chat import chat_page
+from .ingest import ingest_page
+from .evaluate import evaluate_page
+from .settings import settings_page
+from .navbar import render_navbar
+
+__all__ = [
+    "chat_page",
+    "ingest_page",
+    "evaluate_page",
+    "settings_page",
+    "render_navbar",
+]

--- a/src/ui/chat.py
+++ b/src/ui/chat.py
@@ -1,0 +1,11 @@
+import gradio as gr
+
+from .navbar import render_navbar
+
+
+def chat_page() -> gr.Blocks:
+    """Build the chat page."""
+    with gr.Blocks() as demo:
+        render_navbar()
+        gr.Markdown("# Chat")
+    return demo

--- a/src/ui/evaluate.py
+++ b/src/ui/evaluate.py
@@ -1,0 +1,11 @@
+import gradio as gr
+
+from .navbar import render_navbar
+
+
+def evaluate_page() -> gr.Blocks:
+    """Build the evaluation page."""
+    with gr.Blocks() as demo:
+        render_navbar()
+        gr.Markdown("# Evaluate")
+    return demo

--- a/src/ui/ingest.py
+++ b/src/ui/ingest.py
@@ -1,0 +1,11 @@
+import gradio as gr
+
+from .navbar import render_navbar
+
+
+def ingest_page() -> gr.Blocks:
+    """Build the ingest page."""
+    with gr.Blocks() as demo:
+        render_navbar()
+        gr.Markdown("# Ingest")
+    return demo

--- a/src/ui/navbar.py
+++ b/src/ui/navbar.py
@@ -1,0 +1,10 @@
+import gradio as gr
+
+
+def render_navbar() -> None:
+    """Render a simple navigation bar with links to all pages."""
+    with gr.Row():
+        gr.Markdown(
+            "[Chat](/) | [Ingest](/ingest) | "
+            "[Evaluate](/evaluate) | [Settings](/settings)"
+        )

--- a/src/ui/settings.py
+++ b/src/ui/settings.py
@@ -1,0 +1,11 @@
+import gradio as gr
+
+from .navbar import render_navbar
+
+
+def settings_page() -> gr.Blocks:
+    """Build the settings page."""
+    with gr.Blocks() as demo:
+        render_navbar()
+        gr.Markdown("# Settings")
+    return demo

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+
+from app import app
+
+
+def test_default_route_renders_chat() -> None:
+    client = TestClient(app)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "Chat" in resp.text


### PR DESCRIPTION
## Description:
- add FastAPI-based app mounting Gradio routes for chat, ingest, evaluate, and settings
- implement shared navigation bar across all pages
- verify default route serves Chat page

## Testing Done:
- `python -m pytest tests/ -v`

## Performance Impact:
- N/A

## Configuration Changes:
- N/A

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bc42b55ccc8322ab400ea15cd5a637