### PR TITLE
feat(ui): add streaming chat interface

### DIFF
--- a/src/ui/chat.py
+++ b/src/ui/chat.py
@@ -1,11 +1,50 @@
+import json
+from datetime import datetime
+from html import escape
+from pathlib import Path
+from typing import Generator, List, Tuple
+
 import gradio as gr
 
 from .navbar import render_navbar
+
+HISTORY_PATH = Path("chat_history.jsonl")
+
+
+def _sanitize(text: str) -> str:
+    """Escape HTML and trim whitespace from user inputs."""
+    return escape(text.strip())
+
+
+def _append_history(user_message: str, bot_message: str) -> None:
+    """Persist a chat exchange to disk."""
+    record = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "user": user_message,
+        "bot": bot_message,
+    }
+    HISTORY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with HISTORY_PATH.open("a", encoding="utf-8") as file:
+        file.write(json.dumps(record) + "\n")
+
+
+def _generate_response(
+    message: str, history: List[Tuple[str, str]]
+) -> Generator[str, None, None]:
+    """Stream an echo response with typing indicator."""
+    sanitized = _sanitize(message)
+    reply = f"You said: {sanitized}"
+    for token in reply.split():
+        yield token + " "
+    _append_history(sanitized, reply)
 
 
 def chat_page() -> gr.Blocks:
     """Build the chat page."""
     with gr.Blocks() as demo:
         render_navbar()
-        gr.Markdown("# Chat")
+        gr.ChatInterface(
+            fn=_generate_response,
+            title="Chat",
+        )
     return demo

--- a/tests/test_ui/test_chat.py
+++ b/tests/test_ui/test_chat.py
@@ -1,0 +1,49 @@
+import json
+
+import gradio as gr
+
+from src.ui.chat import (
+    _append_history,
+    _generate_response,
+    _sanitize,
+    chat_page,
+    HISTORY_PATH,
+)
+
+
+def test_sanitize_html():
+    assert _sanitize(" <b>hi</b> ") == "&lt;b&gt;hi&lt;/b&gt;"
+
+
+def test_append_history_writes(tmp_path):
+    file_path = tmp_path / "history.jsonl"
+    original = HISTORY_PATH
+    try:
+        # patch path
+        from src.ui import chat
+
+        chat.HISTORY_PATH = file_path
+        _append_history("u", "b")
+        data = file_path.read_text().strip().splitlines()
+        record = json.loads(data[0])
+        assert record["user"] == "u"
+        assert record["bot"] == "b"
+    finally:
+        chat.HISTORY_PATH = original
+
+
+def test_generate_response_streams(tmp_path):
+    file_path = tmp_path / "history.jsonl"
+    from src.ui import chat
+
+    chat.HISTORY_PATH = file_path
+    gen = _generate_response("hello world", [])
+    tokens = list(gen)
+    assert len(tokens) > 1
+    assert "You said:" in "".join(tokens)
+    chat.HISTORY_PATH = HISTORY_PATH
+
+
+def test_chat_page_has_chat_interface():
+    page = chat_page()
+    assert any(isinstance(b, gr.Chatbot) for b in page.blocks.values())


### PR DESCRIPTION
## Description:
- implement ChatInterface with streaming responses and persisted history
- add unit tests for chat utilities and UI wiring

## Testing Done:
- `black src/ tests/ app.py`
- `flake8 src/ tests/ app.py`
- `mypy --ignore-missing-imports src/ app.py`
- `python -m pytest tests/ -v`

## Performance Impact:
- n/a

## Configuration Changes:
- n/a

## Evaluation Results:
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68bc4545c3d083229204be08655ffd62