### PR TITLE
feat(evaluation): integrate Ragas faithfulness scoring

### DIFF
--- a/src/evaluation/__init__.py
+++ b/src/evaluation/__init__.py
@@ -1,0 +1,1 @@
+"""Evaluation package."""

--- a/src/evaluation/ragas_integration.py
+++ b/src/evaluation/ragas_integration.py
@@ -1,0 +1,65 @@
+"""Ragas evaluation utilities."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, List
+
+from ragas import evaluate
+from ragas.metrics import faithfulness
+
+
+@dataclass
+class EvaluationResult:
+    """Container for a single evaluation."""
+
+    timestamp: str
+    query: str
+    answer: str
+    contexts: List[str]
+    score: float
+    rationale: str
+
+
+class RagasEvaluator:
+    """Compute faithfulness scores using Ragas."""
+
+    def __init__(
+        self, history_path: Path | str = "evaluation_history.jsonl"
+    ) -> None:  # noqa: E501
+        self.history_path = Path(history_path)
+        self.history: List[EvaluationResult] = []
+
+    def evaluate(
+        self, query: str, answer: str, contexts: List[str]
+    ) -> EvaluationResult:
+        """Evaluate an answer's faithfulness against contexts."""
+        data = {
+            "question": [query],
+            "answer": [answer],
+            "contexts": [contexts],
+        }
+        rationale: str
+        try:
+            result: Any = evaluate(data, metrics=[faithfulness])
+            score = float(result["faithfulness"][0])
+            rationale = "Computed using Ragas faithfulness metric."
+        except Exception as exc:  # pragma: no cover - safety net
+            score = 0.0
+            rationale = f"Evaluation failed: {exc}"
+        record = EvaluationResult(
+            timestamp=datetime.utcnow().isoformat(),
+            query=query,
+            answer=answer,
+            contexts=contexts,
+            score=score,
+            rationale=rationale,
+        )
+        self.history.append(record)
+        self.history_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.history_path.open("a", encoding="utf-8") as file:
+            file.write(json.dumps(record.__dict__) + "\n")
+        return record

--- a/src/ui/chat.py
+++ b/src/ui/chat.py
@@ -7,8 +7,10 @@ from typing import Generator, List, Tuple
 import gradio as gr
 
 from .navbar import render_navbar
+from ..evaluation.ragas_integration import RagasEvaluator
 
 HISTORY_PATH = Path("chat_history.jsonl")
+EVALUATOR = RagasEvaluator()
 
 
 def _sanitize(text: str) -> str:
@@ -37,6 +39,7 @@ def _generate_response(
     for token in reply.split():
         yield token + " "
     _append_history(sanitized, reply)
+    EVALUATOR.evaluate(sanitized, reply, [sanitized])
 
 
 def chat_page() -> gr.Blocks:

--- a/tests/test_evaluation/test_ragas_integration.py
+++ b/tests/test_evaluation/test_ragas_integration.py
@@ -1,0 +1,18 @@
+import json
+from unittest.mock import patch
+
+from src.evaluation.ragas_integration import RagasEvaluator
+
+
+def test_evaluate_records_history(tmp_path):
+    file_path = tmp_path / "history.jsonl"
+    evaluator = RagasEvaluator(history_path=file_path)
+
+    with patch("src.evaluation.ragas_integration.evaluate") as mock_eval:
+        mock_eval.return_value = {"faithfulness": [0.9]}
+        result = evaluator.evaluate("q", "a", ["c"])
+
+    assert 0 <= result.score <= 1
+    line = file_path.read_text().strip().splitlines()[0]
+    data = json.loads(line)
+    assert data["score"] == 0.9

--- a/tests/test_ui/test_chat.py
+++ b/tests/test_ui/test_chat.py
@@ -37,11 +37,14 @@ def test_generate_response_streams(tmp_path):
     from src.ui import chat
 
     chat.HISTORY_PATH = file_path
+    original_eval_path = chat.EVALUATOR.history_path
+    chat.EVALUATOR.history_path = tmp_path / "eval.jsonl"
     gen = _generate_response("hello world", [])
     tokens = list(gen)
     assert len(tokens) > 1
     assert "You said:" in "".join(tokens)
     chat.HISTORY_PATH = HISTORY_PATH
+    chat.EVALUATOR.history_path = original_eval_path
 
 
 def test_chat_page_has_chat_interface():


### PR DESCRIPTION
## Description:
- add RagasEvaluator to compute faithfulness scores and log results
- trigger evaluation after each chat turn

## Testing Done:
- `black src/ tests/ app.py`
- `flake8 src/ tests/ app.py`
- `mypy src/ app.py --ignore-missing-imports`
- `python -m pytest tests/ -v`

## Performance Impact:
- no significant impact

## Configuration Changes:
- none

## Evaluation Results:
- faithfulness score recorded during tests (mocked 0.9)


------
https://chatgpt.com/codex/tasks/task_e_68bc47a9ade08322bfc0543f7e272f78