### PR TITLE
feat(services): add document ingestion with parsing and indexing

### DIFF
--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer modules."""

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -1,0 +1,115 @@
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, List
+
+from src.retrieval.dense import DenseRetriever
+from src.retrieval.lexical import LexicalBM25
+
+
+class DocumentService:
+    """Handle document parsing, chunking, and indexing."""
+
+    def __init__(
+        self,
+        dense_retriever: DenseRetriever,
+        lexical_retriever: LexicalBM25,
+        chunk_size: int = 500,
+        overlap: int = 50,
+    ) -> None:
+        self._logger = logging.getLogger(__name__)
+        self.dense_retriever = dense_retriever
+        self.lexical_retriever = lexical_retriever
+        self.chunk_size = chunk_size
+        self.overlap = overlap
+
+    # Parsing helpers
+    def parse_document(self, file_path: str) -> str:
+        """Parse a document from various formats into plain text."""
+        path = Path(file_path)
+        suffix = path.suffix.lower()
+        try:
+            if suffix == ".pdf":
+                try:
+                    from pypdf import PdfReader
+                except Exception as exc:  # pragma: no cover
+                    raise RuntimeError("pypdf is required for PDF parsing") from exc
+                with path.open("rb") as fh:
+                    reader = PdfReader(fh)
+                    text = "\n".join(page.extract_text() or "" for page in reader.pages)
+            elif suffix == ".docx":
+                try:
+                    from docx import Document  # type: ignore
+                except Exception as exc:  # pragma: no cover
+                    raise RuntimeError(
+                        "python-docx is required for DOCX parsing"
+                    ) from exc
+                doc = Document(path)
+                text = "\n".join(p.text for p in doc.paragraphs)
+            elif suffix in {".txt", ".md", ".html", ".htm"}:
+                with path.open("r", encoding="utf-8", errors="ignore") as fh:
+                    data = fh.read()
+                if suffix in {".html", ".htm"}:
+                    text = self._html_to_text(data)
+                elif suffix == ".md":
+                    text = self._markdown_to_text(data)
+                else:
+                    text = data
+            else:
+                raise ValueError(f"Unsupported file type: {suffix}")
+            return text.strip()
+        except Exception as exc:  # pragma: no cover
+            self._logger.error("Failed to parse %s: %s", path, exc)
+            raise
+
+    def _html_to_text(self, data: str) -> str:
+        try:
+            from bs4 import BeautifulSoup
+
+            soup = BeautifulSoup(data, "html.parser")
+            return soup.get_text(separator=" ")
+        except Exception:  # pragma: no cover
+            return re.sub(r"<[^>]+>", " ", data)
+
+    def _markdown_to_text(self, data: str) -> str:
+        try:
+            import markdown
+
+            html = markdown.markdown(data)
+            return self._html_to_text(html)
+        except Exception:  # pragma: no cover
+            return data
+
+    # Chunking
+    def chunk_text(self, text: str) -> List[str]:
+        words = text.split()
+        if not words:
+            return []
+        chunks: List[str] = []
+        step = max(self.chunk_size - self.overlap, 1)
+        for start in range(0, len(words), step):
+            end = start + self.chunk_size
+            chunk_words = words[start:end]
+            if chunk_words:
+                chunks.append(" ".join(chunk_words))
+            if end >= len(words):
+                break
+        return chunks
+
+    # Ingestion
+    def ingest(self, file_paths: List[str]) -> Dict[str, Any]:
+        """Parse files, chunk text, and update both indexes."""
+        all_chunks: List[str] = []
+        metadatas: List[Dict[str, Any]] = []
+        for file_path in file_paths:
+            text = self.parse_document(file_path)
+            chunks = self.chunk_text(text)
+            for idx, chunk in enumerate(chunks):
+                all_chunks.append(chunk)
+                metadatas.append({"source": str(file_path), "chunk": idx})
+        dense_ids, dense_meta = self.dense_retriever.index_corpus(all_chunks, metadatas)
+        lexical_ids, lexical_meta = self.lexical_retriever.index_documents(all_chunks)
+        return {
+            "dense": {"ids": dense_ids, **dense_meta},
+            "lexical": {"ids": lexical_ids, **lexical_meta},
+        }

--- a/tests/test_services/test_document_service.py
+++ b/tests/test_services/test_document_service.py
@@ -1,0 +1,79 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.services.document_service import DocumentService
+
+
+@pytest.fixture
+def mocks():
+    dense = MagicMock()
+    lexical = MagicMock()
+    dense.index_corpus.return_value = (["1", "2"], {"status": "success", "count": 2})
+    lexical.index_documents.return_value = (
+        ["1", "2"],
+        {"status": "success", "count": 2},
+    )
+    return dense, lexical
+
+
+def create_pdf(path: Path) -> None:
+    from fpdf import FPDF
+
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+    pdf.cell(200, 10, txt="Hello PDF", ln=True)
+    pdf.output(path)
+
+
+def create_docx(path: Path) -> None:
+    from docx import Document
+
+    doc = Document()
+    doc.add_paragraph("Hello DOCX")
+    doc.save(path)
+
+
+def test_parse_various_formats(tmp_path, mocks):
+    dense, lexical = mocks
+    service = DocumentService(dense, lexical)
+
+    txt_file = tmp_path / "sample.txt"
+    txt_file.write_text("hello txt")
+    assert "hello txt" in service.parse_document(str(txt_file))
+
+    html_file = tmp_path / "sample.html"
+    html_file.write_text("<html><body><p>Hello <b>HTML</b></p></body></html>")
+    assert "Hello HTML" in service.parse_document(str(html_file))
+
+    md_file = tmp_path / "sample.md"
+    md_file.write_text("# Title\n\nHello MD")
+    parsed_md = service.parse_document(str(md_file))
+    assert "Title" in parsed_md and "Hello MD" in parsed_md
+
+    if importlib.util.find_spec("fpdf") and importlib.util.find_spec("pypdf"):
+        pdf_file = tmp_path / "sample.pdf"
+        create_pdf(pdf_file)
+        assert "Hello PDF" in service.parse_document(str(pdf_file))
+
+    if importlib.util.find_spec("docx"):
+        docx_file = tmp_path / "sample.docx"
+        create_docx(docx_file)
+        assert "Hello DOCX" in service.parse_document(str(docx_file))
+
+
+def test_chunk_and_ingest(tmp_path, mocks):
+    dense, lexical = mocks
+    service = DocumentService(dense, lexical, chunk_size=3, overlap=1)
+    file = tmp_path / "text.txt"
+    file.write_text("one two three four five")
+    result = service.ingest([str(file)])
+
+    expected_chunks = ["one two three", "three four five"]
+    assert dense.index_corpus.call_args[0][0] == expected_chunks
+    assert lexical.index_documents.call_args[0][0] == expected_chunks
+    assert result["dense"]["count"] == 2
+    assert result["lexical"]["count"] == 2


### PR DESCRIPTION
## Description:
- implement DocumentService for parsing PDF, DOCX, TXT, HTML, and MD files
- chunk text with configurable size/overlap and update dense and BM25 indexes
- add unit tests for document parsing and ingestion

## Testing Done:
- `black src/ tests/ app.py`
- `flake8 src/ tests/ app.py` *(command not found)*
- `mypy src/ app.py` *(missing dependency errors)*
- `python -m src.config.validate` *(module not found)*
- `python -m pytest tests/ -v` *(missing dependency errors)*

## Performance Impact:
- None

## Configuration Changes:
- None

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bc49b3a0dc83229e376449ff689cb5