### PR TITLE
feat(integrations): add Hugging Face model manager with caching

### DIFF
--- a/src/integrations/huggingface_models.py
+++ b/src/integrations/huggingface_models.py
@@ -1,0 +1,114 @@
+import logging
+import os
+from pathlib import Path
+from typing import Optional, Tuple
+
+try:
+    from huggingface_hub import snapshot_download  # type: ignore
+except Exception as exc:  # pragma: no cover
+    snapshot_download = None  # type: ignore
+    _import_error = exc
+
+
+class HuggingFaceModelManager:
+    """Manage model downloads with caching and version tracking."""
+
+    def __init__(self, cache_dir: Optional[str] = None) -> None:
+        self._logger = logging.getLogger(__name__)
+        self.cache_dir = Path(
+            cache_dir
+            or os.getenv("HF_HOME")
+            or (Path.home() / ".cache" / "huggingface")
+        )
+        if snapshot_download is None:  # pragma: no cover
+            message = f"huggingface_hub library missing: {_import_error}"
+            raise ImportError(message)
+
+    def _model_dir(self, model_id: str) -> Path:
+        safe_name = model_id.replace("/", "__")
+        return self.cache_dir / safe_name
+
+    def _revision_file(self, model_id: str) -> Path:
+        return self._model_dir(model_id) / "revision.txt"
+
+    def _write_revision(self, model_id: str, revision: str) -> None:
+        model_dir = self._model_dir(model_id)
+        model_dir.mkdir(parents=True, exist_ok=True)
+        self._revision_file(model_id).write_text(revision)
+
+    def _read_revision(self, model_id: str) -> Optional[str]:
+        try:
+            return self._revision_file(model_id).read_text().strip()
+        except FileNotFoundError:
+            return None
+
+    def download_model(
+        self,
+        model_id: str,
+        revision: str = "main",
+        fallback_revision: Optional[str] = None,
+    ) -> Tuple[str, str]:
+        """Download a model with caching and fallback handling.
+
+        Returns the local path and the revision used.
+        """
+
+        try:
+            path = snapshot_download(
+                repo_id=model_id,
+                revision=revision,
+                cache_dir=str(self.cache_dir),
+            )
+            self._write_revision(model_id, revision)
+            return path, revision
+        except Exception as exc:  # pragma: no cover
+            self._logger.warning(
+                "Failed to download model %s revision %s: %s",
+                model_id,
+                revision,
+                exc,
+            )
+            cached_revision = self._read_revision(model_id)
+            if cached_revision:
+                try:
+                    path = snapshot_download(
+                        repo_id=model_id,
+                        revision=cached_revision,
+                        cache_dir=str(self.cache_dir),
+                        local_files_only=True,
+                    )
+                    self._logger.info(
+                        "Using cached revision %s for model %s",
+                        cached_revision,
+                        model_id,
+                    )
+                    return path, cached_revision
+                except Exception as cache_exc:  # pragma: no cover
+                    self._logger.warning(
+                        "Failed to load cached revision %s for model %s: %s",
+                        cached_revision,
+                        model_id,
+                        cache_exc,
+                    )
+            if fallback_revision:
+                try:
+                    path = snapshot_download(
+                        repo_id=model_id,
+                        revision=fallback_revision,
+                        cache_dir=str(self.cache_dir),
+                    )
+                    self._write_revision(model_id, fallback_revision)
+                    self._logger.info(
+                        "Using fallback revision %s for model %s",
+                        fallback_revision,
+                        model_id,
+                    )
+                    return path, fallback_revision
+                except Exception as fallback_exc:  # pragma: no cover
+                    self._logger.error(
+                        "Fallback revision %s failed for model %s: %s",
+                        fallback_revision,
+                        model_id,
+                        fallback_exc,
+                    )
+            raise

--- a/tests/test_integrations/test_huggingface_models.py
+++ b/tests/test_integrations/test_huggingface_models.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+from src.integrations import huggingface_models
+from src.integrations.huggingface_models import HuggingFaceModelManager
+
+
+def test_download_success_tracks_revision(tmp_path, monkeypatch):
+    def fake_download(
+        repo_id: str,
+        revision: str,
+        cache_dir: str,
+        local_files_only: bool = False,
+    ) -> str:
+        path = Path(cache_dir) / "downloaded"
+        path.mkdir(parents=True, exist_ok=True)
+        return str(path)
+
+    monkeypatch.setattr(huggingface_models, "snapshot_download", fake_download)
+    manager = HuggingFaceModelManager(cache_dir=str(tmp_path))
+    path, rev = manager.download_model("test/model", revision="123")
+    assert rev == "123"
+    assert Path(path).exists()
+    version_file = tmp_path / "test__model" / "revision.txt"
+    assert version_file.read_text() == "123"
+
+
+def test_download_failure_uses_cached_revision(tmp_path, monkeypatch):
+    cached_dir = tmp_path / "test__model"
+    cached_dir.mkdir()
+    (cached_dir / "revision.txt").write_text("456")
+
+    def fake_download(
+        repo_id: str,
+        revision: str,
+        cache_dir: str,
+        local_files_only: bool = False,
+    ) -> str:
+        if revision == "456" and local_files_only:
+            path = Path(cache_dir) / "cached"
+            path.mkdir(parents=True, exist_ok=True)
+            return str(path)
+        raise Exception("download failed")
+
+    monkeypatch.setattr(huggingface_models, "snapshot_download", fake_download)
+    manager = HuggingFaceModelManager(cache_dir=str(tmp_path))
+    path, rev = manager.download_model("test/model", revision="999")
+    assert rev == "456"
+    assert Path(path).exists()
+
+
+def test_download_failure_uses_fallback_revision(tmp_path, monkeypatch):
+    def fake_download(
+        repo_id: str,
+        revision: str,
+        cache_dir: str,
+        local_files_only: bool = False,
+    ) -> str:
+        if revision == "fallback":
+            path = Path(cache_dir) / "fallback"
+            path.mkdir(parents=True, exist_ok=True)
+            return str(path)
+        raise Exception("download failed")
+
+    monkeypatch.setattr(huggingface_models, "snapshot_download", fake_download)
+    manager = HuggingFaceModelManager(cache_dir=str(tmp_path))
+    path, rev = manager.download_model(
+        "test/model", revision="999", fallback_revision="fallback"
+    )
+    assert rev == "fallback"
+    assert Path(path).exists()
+    version_file = tmp_path / "test__model" / "revision.txt"
+    assert version_file.read_text() == "fallback"


### PR DESCRIPTION
## Description:
- add HuggingFaceModelManager for cached model downloads with revision tracking
- add integration tests for model caching and fallbacks

## Testing Done:
- `flake8 src/integrations/huggingface_models.py tests/test_integrations/test_huggingface_models.py`
- `mypy src/integrations/huggingface_models.py tests/test_integrations/test_huggingface_models.py`
- `python -m pytest tests/ -v` (fails: test_parse_various_formats)

## Performance Impact:
- n/a

## Configuration Changes:
- none

## Evaluation Results:
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68bc4f84ced88322800401ee6323b81d