### PR TITLE
feat(integrations): add pinecone client with batching and retries

### DIFF
--- a/src/integrations/pinecone_client.py
+++ b/src/integrations/pinecone_client.py
@@ -1,12 +1,31 @@
+"""Utility wrapper for interacting with Pinecone indices.
+
+The real Pinecone client is intentionally thin and network bound.  This
+module provides a light repository style abstraction that encapsulates
+common operations (connect, create, upsert, query and delete) while adding
+retry handling and batched upserts that respect rate limits.  The
+implementation deliberately avoids exposing the underlying Pinecone client
+directly so that it can be easily mocked in tests.
+"""
+
 import logging
 import os
-from typing import Any, Dict, List, Optional, Tuple
+import time
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 try:
     import pinecone  # type: ignore
 except Exception as exc:  # pragma: no cover
     pinecone = None
     _import_error = exc
+
+
+EMBEDDING_DIMENSION = 384
+DEFAULT_METRIC = "cosine"
+DEFAULT_BATCH_SIZE = 100
+DEFAULT_REQUESTS_PER_MINUTE = 60
+MAX_RETRIES = 3
+BACKOFF_FACTOR = 1.0
 
 
 class PineconeClient:
@@ -21,7 +40,64 @@ class PineconeClient:
         if pinecone is None:  # pragma: no cover
             message = f"pinecone library missing: {_import_error}"
             raise ImportError(message)
+        self.connect()
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    def _with_retries(self, func: Callable, *args, **kwargs):
+        """Execute ``func`` with basic exponential backoff retry logic."""
+
+        delay = BACKOFF_FACTOR
+        for attempt in range(MAX_RETRIES):
+            try:
+                return func(*args, **kwargs)
+            except Exception as exc:  # pragma: no cover
+                if attempt == MAX_RETRIES - 1:
+                    self._logger.error(
+                        "Operation failed after %s attempts", MAX_RETRIES
+                    )
+                    raise
+                self._logger.warning(
+                    "Operation failed (%s/%s): %s",
+                    attempt + 1,
+                    MAX_RETRIES,
+                    exc,
+                )
+                time.sleep(delay)
+                delay *= 2
+
+    # ------------------------------------------------------------------
+    # connection & index management
+    def connect(self) -> None:
+        """Initialize connection to Pinecone."""
+
         pinecone.init(api_key=self.api_key, environment=self.environment)
+
+    def create_index(
+        self,
+        index_name: str,
+        dimension: int = EMBEDDING_DIMENSION,
+        metric: str = DEFAULT_METRIC,
+        **kwargs: Any,
+    ) -> None:
+        """Create an index if it does not already exist."""
+
+        if index_name in pinecone.list_indexes():
+            return
+        self._with_retries(
+            pinecone.create_index,
+            name=index_name,
+            dimension=dimension,
+            metric=metric,
+            **kwargs,
+        )
+
+    def delete_index(self, index_name: str) -> None:
+        """Delete an index if it exists."""
+
+        if index_name not in pinecone.list_indexes():
+            return
+        self._with_retries(pinecone.delete_index, index_name)
 
     def get_index(self, index_name: str):
         return pinecone.Index(index_name)
@@ -47,9 +123,28 @@ class PineconeClient:
         self,
         index_name: str,
         vectors: List[Tuple[str, List[float], Dict[str, Any]]],
+        namespace: Optional[str] = None,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        requests_per_minute: int = DEFAULT_REQUESTS_PER_MINUTE,
     ) -> None:
+        """Upsert embeddings in batches, respecting rate limits."""
+
+        self.validate_index(index_name, EMBEDDING_DIMENSION)
         index = self.get_index(index_name)
-        index.upsert(vectors=vectors)
+        sleep_time = 0.0
+        if requests_per_minute > 0:
+            sleep_time = 60.0 / float(requests_per_minute)
+
+        for start in range(0, len(vectors), batch_size):
+            batch = vectors[start : start + batch_size]  # noqa: E203
+            self._with_retries(
+                index.upsert,
+                vectors=batch,
+                namespace=namespace,
+            )
+            # Sleep between requests except after the last batch
+            if sleep_time and start + batch_size < len(vectors):
+                time.sleep(sleep_time)
 
     def query(
         self,
@@ -57,8 +152,10 @@ class PineconeClient:
         embedding: List[float],
         top_k: int = 5,
     ) -> Any:
+        self.validate_index(index_name, EMBEDDING_DIMENSION)
         index = self.get_index(index_name)
-        return index.query(
+        return self._with_retries(
+            index.query,
             vector=embedding,
             top_k=top_k,
             include_metadata=True,

--- a/tests/test_integrations/test_pinecone_client.py
+++ b/tests/test_integrations/test_pinecone_client.py
@@ -1,0 +1,147 @@
+import types
+from typing import Any, Dict, List
+
+from src.integrations import pinecone_client
+from src.integrations.pinecone_client import (
+    EMBEDDING_DIMENSION,
+    PineconeClient,
+)
+
+
+class FakeIndex:
+    def __init__(
+        self, fail_upsert_times: int = 0, fail_query_times: int = 0
+    ) -> None:  # noqa: E501
+        self.fail_upsert_times = fail_upsert_times
+        self.fail_query_times = fail_query_times
+        self.upsert_call_count = 0
+        self.upsert_success_calls: List[List[Any]] = []
+        self.query_call_count = 0
+
+    def upsert(self, vectors, namespace=None):
+        self.upsert_call_count += 1
+        if self.fail_upsert_times > 0:
+            self.fail_upsert_times -= 1
+            raise Exception("network")
+        self.upsert_success_calls.append(vectors)
+
+    def query(self, vector, top_k, include_metadata, namespace=None):
+        self.query_call_count += 1
+        if self.fail_query_times > 0:
+            self.fail_query_times -= 1
+            raise Exception("network")
+        return {"matches": []}
+
+
+def test_create_index_retries(monkeypatch):
+    calls: Dict[str, int] = {"create": 0, "init": 0}
+
+    def fake_init(api_key=None, environment=None):
+        calls["init"] += 1
+
+    def fake_list_indexes():
+        return []
+
+    def fake_create_index(name, dimension, metric):
+        calls["create"] += 1
+        assert dimension == EMBEDDING_DIMENSION
+        assert metric == "cosine"
+        if calls["create"] == 1:
+            raise Exception("transient")
+
+    fake_pinecone = types.SimpleNamespace(
+        init=fake_init,
+        list_indexes=fake_list_indexes,
+        create_index=fake_create_index,
+        delete_index=lambda name: None,
+        Index=lambda name: FakeIndex(),
+        describe_index=lambda name: types.SimpleNamespace(
+            dimension=EMBEDDING_DIMENSION
+        ),
+    )
+    monkeypatch.setattr(pinecone_client, "pinecone", fake_pinecone)
+
+    client = PineconeClient(api_key="key", environment="env")
+    client.create_index("test-index")
+    assert calls["create"] == 2
+    assert calls["init"] == 1
+
+
+def test_delete_index_retries(monkeypatch):
+    calls: Dict[str, int] = {"delete": 0}
+
+    def fake_delete_index(name):
+        calls["delete"] += 1
+        if calls["delete"] == 1:
+            raise Exception("fail")
+
+    fake_pinecone = types.SimpleNamespace(
+        init=lambda api_key=None, environment=None: None,
+        list_indexes=lambda: ["test-index"],
+        delete_index=fake_delete_index,
+        Index=lambda name: FakeIndex(),
+        create_index=lambda **kwargs: None,
+        describe_index=lambda name: types.SimpleNamespace(
+            dimension=EMBEDDING_DIMENSION
+        ),
+    )
+    monkeypatch.setattr(pinecone_client, "pinecone", fake_pinecone)
+
+    client = PineconeClient(api_key="key", environment="env")
+    client.delete_index("test-index")
+    assert calls["delete"] == 2
+
+
+def test_upsert_batches_and_retries(monkeypatch):
+    index = FakeIndex(fail_upsert_times=1)
+
+    fake_pinecone = types.SimpleNamespace(
+        init=lambda api_key=None, environment=None: None,
+        Index=lambda name: index,
+        describe_index=lambda name: types.SimpleNamespace(
+            dimension=EMBEDDING_DIMENSION
+        ),
+        list_indexes=lambda: [],
+        create_index=lambda **kwargs: None,
+        delete_index=lambda name: None,
+    )
+    monkeypatch.setattr(pinecone_client, "pinecone", fake_pinecone)
+
+    client = PineconeClient(api_key="key", environment="env")
+    sleep_calls: List[float] = []
+    monkeypatch.setattr(
+        pinecone_client.time,
+        "sleep",
+        lambda s: sleep_calls.append(s),
+    )
+    vectors = [(str(i), [0.0] * EMBEDDING_DIMENSION, {}) for i in range(250)]
+    client.upsert_embeddings(
+        "test",
+        vectors,
+        batch_size=100,
+        requests_per_minute=120,
+    )
+    assert index.upsert_call_count == 4  # first batch retried
+    assert [len(b) for b in index.upsert_success_calls] == [100, 100, 50]
+    assert sleep_calls == [1.0, 0.5, 0.5]
+
+
+def test_query_retries(monkeypatch):
+    index = FakeIndex(fail_query_times=1)
+
+    fake_pinecone = types.SimpleNamespace(
+        init=lambda api_key=None, environment=None: None,
+        Index=lambda name: index,
+        describe_index=lambda name: types.SimpleNamespace(
+            dimension=EMBEDDING_DIMENSION
+        ),
+        list_indexes=lambda: [],
+        create_index=lambda **kwargs: None,
+        delete_index=lambda name: None,
+    )
+    monkeypatch.setattr(pinecone_client, "pinecone", fake_pinecone)
+
+    client = PineconeClient(api_key="key", environment="env")
+    result = client.query("test", [0.1] * EMBEDDING_DIMENSION, top_k=5)
+    assert result == {"matches": []}
+    assert index.query_call_count == 2


### PR DESCRIPTION
## Description:
- implement pinecone client with connection management and retry logic
- support batched upserts with rate limiting
- add unit tests for index operations, batching, and retries

## Testing Done:
- `flake8 src/integrations/pinecone_client.py tests/test_integrations/test_pinecone_client.py`
- `mypy src/integrations/pinecone_client.py`
- `pytest tests/test_integrations/test_pinecone_client.py -v`

## Performance Impact:
- n/a

## Configuration Changes:
- none

## Evaluation Results:
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68bc51a0a7308322b095662758c3be72