### PR TITLE
feat(retrieval): add query-aware weighting

### DIFF
--- a/src/retrieval/query_analysis.py
+++ b/src/retrieval/query_analysis.py
@@ -1,0 +1,47 @@
+"""Query analysis utilities for dynamic weighting."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Tuple
+
+from .lexical import LexicalBM25
+
+RARE_TOKEN_PATTERN = re.compile(r"[A-Z]{2,}\-?\d+")
+
+
+def analyze_query(
+    query: str,
+    lexical: LexicalBM25,
+    *,
+    w_dense: float = 1.0,
+    w_lexical: float = 1.0,
+) -> Tuple[Dict[str, float], Dict[str, Any]]:
+    """Analyze query terms and adjust component weights.
+
+    Adjust weights toward lexical retrieval when the query contains rare
+    tokens or pattern-matching identifiers such as ``AB-123``. Uses BM25 IDF
+    statistics when available.
+    """
+
+    has_identifier = bool(RARE_TOKEN_PATTERN.search(query))
+
+    idf_scores = []
+    bm25 = getattr(lexical, "bm25", None)
+    if bm25:
+        tokens = re.findall(r"\b\w+\b", query.lower())
+        idf_scores = [bm25.idf.get(tok, 0.0) for tok in tokens]
+    avg_idf = sum(idf_scores) / len(idf_scores) if idf_scores else 0.0
+
+    weights = {"w_dense": w_dense, "w_lexical": w_lexical}
+    if has_identifier or avg_idf > 2.0:
+        weights["w_dense"] = w_dense * 0.7
+        weights["w_lexical"] = w_lexical * 1.3
+
+    meta = {
+        "rrf_weights": {
+            "dense": weights["w_dense"],
+            "lexical": weights["w_lexical"],
+        }
+    }
+    return weights, meta

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -33,10 +33,14 @@ class DocumentService:
                 try:
                     from pypdf import PdfReader
                 except Exception as exc:  # pragma: no cover
-                    raise RuntimeError("pypdf is required for PDF parsing") from exc
+                    raise RuntimeError(
+                        "pypdf is required for PDF parsing"
+                    ) from exc
                 with path.open("rb") as fh:
                     reader = PdfReader(fh)
-                    text = "\n".join(page.extract_text() or "" for page in reader.pages)
+                    text = "\n".join(
+                        page.extract_text() or "" for page in reader.pages
+                    )
             elif suffix == ".docx":
                 try:
                     from docx import Document  # type: ignore
@@ -67,9 +71,11 @@ class DocumentService:
             from bs4 import BeautifulSoup
 
             soup = BeautifulSoup(data, "html.parser")
-            return soup.get_text(separator=" ")
+            text = soup.get_text(separator=" ")
+            return " ".join(text.split())
         except Exception:  # pragma: no cover
-            return re.sub(r"<[^>]+>", " ", data)
+            stripped = re.sub(r"<[^>]+>", " ", data)
+            return " ".join(stripped.split())
 
     def _markdown_to_text(self, data: str) -> str:
         try:
@@ -107,8 +113,12 @@ class DocumentService:
             for idx, chunk in enumerate(chunks):
                 all_chunks.append(chunk)
                 metadatas.append({"source": str(file_path), "chunk": idx})
-        dense_ids, dense_meta = self.dense_retriever.index_corpus(all_chunks, metadatas)
-        lexical_ids, lexical_meta = self.lexical_retriever.index_documents(all_chunks)
+        dense_ids, dense_meta = self.dense_retriever.index_corpus(
+            all_chunks, metadatas
+        )
+        lexical_ids, lexical_meta = self.lexical_retriever.index_documents(
+            all_chunks
+        )
         return {
             "dense": {"ids": dense_ids, **dense_meta},
             "lexical": {"ids": lexical_ids, **lexical_meta},

--- a/tests/test_retrieval/test_hybrid.py
+++ b/tests/test_retrieval/test_hybrid.py
@@ -27,3 +27,24 @@ def test_mode_selection_dense_and_lexical():
     assert all(r["source"] == "dense" for r in dense_only)
     lexical_only, _ = hybrid.query("test", mode="lexical")
     assert all(r["source"] == "lexical" for r in lexical_only)
+
+
+def _build_hybrid_with_lexical_corpus():
+    from src.retrieval.lexical import LexicalBM25
+
+    lex = LexicalBM25()
+    lex.index_documents(["alpha beta", "gamma delta", "AB-123 device"])
+    return HybridRetriever(StubDense(), lex)
+
+
+def test_common_language_query_keeps_default_weights():
+    hybrid = _build_hybrid_with_lexical_corpus()
+    _, meta = hybrid.query("alpha beta")
+    assert meta["rrf_weights"]["dense"] == 1.0
+    assert meta["rrf_weights"]["lexical"] == 1.0
+
+
+def test_rare_token_query_shifts_toward_lexical():
+    hybrid = _build_hybrid_with_lexical_corpus()
+    _, meta = hybrid.query("AB-123 malfunction")
+    assert meta["rrf_weights"]["lexical"] > meta["rrf_weights"]["dense"]

--- a/tests/test_services/test_document_service.py
+++ b/tests/test_services/test_document_service.py
@@ -11,7 +11,10 @@ from src.services.document_service import DocumentService
 def mocks():
     dense = MagicMock()
     lexical = MagicMock()
-    dense.index_corpus.return_value = (["1", "2"], {"status": "success", "count": 2})
+    dense.index_corpus.return_value = (
+        ["1", "2"],
+        {"status": "success", "count": 2},
+    )
     lexical.index_documents.return_value = (
         ["1", "2"],
         {"status": "success", "count": 2},


### PR DESCRIPTION
## Description:
- analyze query terms via IDF and token pattern to adjust hybrid weights
- integrate query analysis into hybrid retriever
- cover rare-token and common-language cases in tests
- normalize HTML text extraction to remove double spaces

## Testing Done:
- `black src/ tests/ app.py`
- `flake8 src/ tests/ app.py`
- `mypy src/ app.py` *(fails: missing type stubs for rank_bm25, nltk, yaml)*
- `python -m pytest tests/ -v`

## Performance Impact:
- no performance regressions expected

## Configuration Changes:
- none

## Evaluation Results:
- not applicable


------
https://chatgpt.com/codex/tasks/task_e_68bc69c36b548322a6bb8f7e6db75428