### PR TITLE
feat(ranking): add reranker with caching and timeout

### DIFF
--- a/src/ranking/__init__.py
+++ b/src/ranking/__init__.py
@@ -1,0 +1,3 @@
+from .reranker import CrossEncoderReranker
+
+__all__ = ["CrossEncoderReranker"]

--- a/src/ranking/reranker.py
+++ b/src/ranking/reranker.py
@@ -1,0 +1,106 @@
+import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
+from typing import Any, Dict, List, Tuple
+
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+
+class CrossEncoderReranker:
+    """Cross-encoder reranker using BAAI/bge-reranker-v2-m3."""
+
+    def __init__(
+        self,
+        model_name: str = "BAAI/bge-reranker-v2-m3",
+        cache_ttl: int = 300,
+        load_model: bool = True,
+    ) -> None:
+        self.model_name = model_name
+        self.cache_ttl = cache_ttl
+        self.cache: Dict[
+            Tuple[str, str, Tuple[str, ...]],
+            Tuple[List[Dict[str, Any]], float],
+        ] = {}
+        self.executor = ThreadPoolExecutor(max_workers=1)
+        if load_model:
+            self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+            self.model = (
+                AutoModelForSequenceClassification.from_pretrained(  # noqa: E501
+                    model_name
+                )
+            )
+            self.model.to("cpu")
+        else:  # pragma: no cover - used in tests to avoid heavy model load
+            self.tokenizer = None  # type: ignore
+            self.model = None  # type: ignore
+
+    def _score_pairs(self, query: str, texts: List[str]) -> List[float]:
+        """Return relevance scores for query-document pairs."""
+        inputs = self.tokenizer(
+            [query] * len(texts),
+            texts,
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+        )
+        with torch.no_grad():
+            logits = self.model(**inputs).logits.squeeze(-1)
+        return logits.tolist()
+
+    def rerank(
+        self,
+        query: str,
+        docs: List[Dict[str, Any]],
+        top_k: int = 5,
+        *,
+        session_id: str = "default",
+        timeout: float = 1.0,
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        """Rerank docs for a query returning top_k results.
+
+        Applies session-based caching and enforces a timeout. If the estimated
+        time exceeds the timeout or the operation times out, original ranking
+        is returned with reranked=False metadata.
+        """
+
+        start = time.perf_counter()
+        top_docs = docs[:20]
+        key = (session_id, query, tuple(d["id"] for d in top_docs))
+        entry = self.cache.get(key)
+        if entry and (time.perf_counter() - entry[1]) < self.cache_ttl:
+            latency_ms = int((time.perf_counter() - start) * 1000)
+            meta = {"reranked": True, "latency_ms": latency_ms, "cached": True}
+            return entry[0][:top_k], meta
+
+        if not top_docs:
+            latency_ms = int((time.perf_counter() - start) * 1000)
+            return [], {"reranked": False, "latency_ms": latency_ms}
+
+        eta_ms = len(top_docs) * 50
+        if eta_ms > timeout * 1000:
+            latency_ms = int((time.perf_counter() - start) * 1000)
+            return top_docs[:top_k], {
+                "reranked": False,
+                "latency_ms": latency_ms,
+            }
+
+        future = self.executor.submit(
+            self._score_pairs, query, [d.get("text", "") for d in top_docs]
+        )
+        try:
+            scores = future.result(timeout=timeout)
+        except TimeoutError:
+            latency_ms = int((time.perf_counter() - start) * 1000)
+            return top_docs[:top_k], {
+                "reranked": False,
+                "latency_ms": latency_ms,
+            }
+
+        ranked = sorted(
+            ({**doc, "score": score} for doc, score in zip(top_docs, scores)),
+            key=lambda x: x["score"],
+            reverse=True,
+        )
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        self.cache[key] = (ranked, time.perf_counter())
+        return ranked[:top_k], {"reranked": True, "latency_ms": latency_ms}

--- a/tests/test_ranking/test_reranker.py
+++ b/tests/test_ranking/test_reranker.py
@@ -1,0 +1,40 @@
+import time
+
+from src.ranking.reranker import CrossEncoderReranker
+
+
+def _build_docs(ids):
+    return [{"id": i, "text": f"text {i}"} for i in ids]
+
+
+def test_reranker_orders_by_score(monkeypatch):
+    reranker = CrossEncoderReranker(load_model=False)
+
+    def fake_scores(query, texts):
+        return [0.1, 0.9, 0.5]
+
+    reranker._score_pairs = fake_scores  # type: ignore
+    docs = _build_docs(["d1", "d2", "d3"])
+    results, meta = reranker.rerank("q", docs, top_k=2, session_id="s1")
+    assert [r["id"] for r in results] == ["d2", "d3"]
+    assert meta["reranked"]
+
+
+def test_reranker_timeout_fallback(monkeypatch):
+    reranker = CrossEncoderReranker(load_model=False)
+
+    def slow_scores(query, texts):
+        time.sleep(0.05)
+        return [0.0 for _ in texts]
+
+    reranker._score_pairs = slow_scores  # type: ignore
+    docs = _build_docs(["d1", "d2"])
+    results, meta = reranker.rerank(
+        "q",
+        docs,
+        top_k=2,
+        session_id="s2",
+        timeout=0.01,
+    )
+    assert [r["id"] for r in results] == ["d1", "d2"]
+    assert not meta["reranked"]

--- a/tests/test_retrieval/test_hybrid_rerank.py
+++ b/tests/test_retrieval/test_hybrid_rerank.py
@@ -1,0 +1,32 @@
+from src.retrieval.hybrid import HybridRetriever
+
+
+class StubDense:
+    def query(self, query, top_k=5):
+        return [("a", 0.9), ("b", 0.8)], {}
+
+
+class StubLexical:
+    def __init__(self):
+        self.documents = ["doc a", "doc b"]
+        self.doc_ids = ["a", "b"]
+
+    def query(self, query, top_k=5):
+        return [("a", 1.0), ("b", 0.5)], {}
+
+
+class StubReranker:
+    def rerank(self, query, docs, top_k=5, session_id="default", timeout=1.0):
+        docs = list(reversed(docs))
+        return docs[:top_k], {"reranked": True, "latency_ms": 1}
+
+
+def test_hybrid_rerank_integration():
+    hybrid = HybridRetriever(
+        StubDense(),
+        StubLexical(),
+        reranker=StubReranker(),
+    )
+    results, meta = hybrid.query("q", enable_rerank=True)
+    assert meta["reranked"]
+    assert results[0]["id"] == "b"


### PR DESCRIPTION
## Description:
- add cross-encoder reranker with session cache and timeout
- wire optional rerank step into hybrid retriever with latency metadata
- test rerank ordering and timeout fallback using mocked model

## Testing Done:
- `flake8 src/ranking/reranker.py src/retrieval/hybrid.py tests/test_ranking/test_reranker.py tests/test_retrieval/test_hybrid_rerank.py`
- `mypy src/ app.py` *(fails: missing stubs for rank_bm25, nltk)*
- `python -m pytest tests/ -v`

## Performance Impact:
- adds optional rerank stage with estimated latency checks; no baseline changes

## Configuration Changes:
- none

## Evaluation Results:
- not applicable


------
https://chatgpt.com/codex/tasks/task_e_68bc6cf080648322bb5c44cc99767f3e