### PR TITLE
feat(ui): add transparency panel

### DIFF
--- a/src/ui/chat.py
+++ b/src/ui/chat.py
@@ -2,10 +2,11 @@ import json
 from datetime import datetime
 from html import escape
 from pathlib import Path
-from typing import Generator, List, Tuple
+from typing import Any, Dict, Generator, List, Tuple
 
 import gradio as gr
 
+from .components.transparency import TransparencyPanel
 from .navbar import render_navbar
 from ..evaluation.ragas_integration import RagasEvaluator
 
@@ -32,22 +33,35 @@ def _append_history(user_message: str, bot_message: str) -> None:
 
 def _generate_response(
     message: str, history: List[Tuple[str, str]]
-) -> Generator[str, None, None]:
-    """Stream an echo response with typing indicator."""
+) -> Generator[Tuple[str, Dict[str, Any]], None, None]:
+    """Stream an echo response with retrieval metadata."""
     sanitized = _sanitize(message)
     reply = f"You said: {sanitized}"
+    metadata = {
+        "citations": [
+            {
+                "label": "input",
+                "link": "https://example.com",
+            }
+        ],
+        "latency": 0.0,
+        "details": {"echo": True, "tokens": len(reply.split())},
+    }
     for token in reply.split():
-        yield token + " "
+        yield token + " ", metadata
     _append_history(sanitized, reply)
     EVALUATOR.evaluate(sanitized, reply, [sanitized])
 
 
 def chat_page() -> gr.Blocks:
     """Build the chat page."""
-    with gr.Blocks() as demo:
+    with gr.Blocks(css=TransparencyPanel.CSS) as demo:
         render_navbar()
+        panel = TransparencyPanel().render()
+        panel.bind()
         gr.ChatInterface(
             fn=_generate_response,
+            additional_outputs=[panel.state],
             title="Chat",
         )
     return demo

--- a/src/ui/components/transparency.py
+++ b/src/ui/components/transparency.py
@@ -1,0 +1,120 @@
+"""Reusable transparency components for the chat interface."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+import gradio as gr
+from html import escape
+
+from gradio.events import EventData
+
+
+@dataclass
+class CitationBadge:
+    """Simple badge representing a citation source."""
+
+    label: str
+    link: Optional[str] = None
+
+    def render(self) -> str:
+        """Return HTML for the badge."""
+        safe_label = escape(self.label)
+        if self.link:
+            safe_link = escape(self.link)
+            return (
+                f'<a href="{safe_link}" target="_blank" '
+                f'class="citation-badge">{safe_label}</a>'
+            )
+        return f'<span class="citation-badge">{safe_label}</span>'
+
+    def on_click(self, event: EventData) -> str:
+        """Return the target label when clicked."""
+        target = getattr(event, "target", None)
+        if isinstance(target, str):
+            return target
+        return self.label
+
+
+@dataclass
+class DetailsDrawer:
+    """Expandable drawer to show retrieval metadata."""
+
+    content: Dict[str, Any] = field(default_factory=dict)
+    open: bool = False
+
+    def render(self) -> gr.Accordion:
+        with gr.Accordion("Details", open=self.open) as acc:
+            self.json = gr.JSON(self.content)
+        return acc
+
+    def toggle(self, event: EventData) -> bool:
+        self.open = not self.open
+        return self.open
+
+    def update(self, content: Dict[str, Any]) -> Dict[str, Any]:
+        self.content = content
+        return gr.update(value=content)
+
+
+@dataclass
+class PerformanceIndicator:
+    """Display simple performance metrics such as latency."""
+
+    latency_ms: float = 0.0
+
+    def render(self) -> gr.Markdown:
+        self.md = gr.Markdown(self.format_latency())
+        return self.md
+
+    def format_latency(self) -> str:
+        return f"**Latency:** {self.latency_ms:.2f} ms"
+
+    def update(self, latency_ms: float) -> Dict[str, str]:
+        self.latency_ms = latency_ms
+        return gr.update(value=self.format_latency())
+
+
+class TransparencyPanel:
+    """Container bundling transparency components with responsive layout."""
+
+    CSS = (
+        ".citation-badge {background:#eee;padding:2px 4px;margin-right:4px;"
+        "border-radius:4px;font-size:0.8rem;}"
+        "@media (max-width: 600px) {"
+        ".transparency-panel {flex-direction:column;}}"
+    )
+
+    def __init__(self) -> None:
+        self.state = gr.State({})
+        self.performance = PerformanceIndicator()
+        self.drawer = DetailsDrawer()
+
+    def render(self) -> "TransparencyPanel":
+        with gr.Row(elem_classes="transparency-panel"):
+            self.badges_html = gr.HTML()
+            self.perf_md = self.performance.render()
+        self.drawer.render()
+        return self
+
+    def bind(self) -> None:
+        self.state.change(
+            self.update,
+            inputs=self.state,
+            outputs=[self.badges_html, self.perf_md, self.drawer.json],
+        )
+
+    def update(self, meta: Dict[str, Any]):
+        citations = [
+            CitationBadge(c.get("label", str(i + 1)), c.get("link")).render()
+            for i, c in enumerate(meta.get("citations", []))
+        ]
+        badges_html = " ".join(citations)
+        latency = meta.get("latency", 0.0)
+        details = meta.get("details", {})
+        return [
+            gr.update(value=badges_html),
+            self.performance.update(latency),
+            self.drawer.update(details),
+        ]

--- a/tests/test_ui/test_chat.py
+++ b/tests/test_ui/test_chat.py
@@ -40,9 +40,11 @@ def test_generate_response_streams(tmp_path):
     original_eval_path = chat.EVALUATOR.history_path
     chat.EVALUATOR.history_path = tmp_path / "eval.jsonl"
     gen = _generate_response("hello world", [])
-    tokens = list(gen)
+    outputs = list(gen)
+    tokens = [t for t, _ in outputs]
     assert len(tokens) > 1
     assert "You said:" in "".join(tokens)
+    assert "citations" in outputs[0][1]
     chat.HISTORY_PATH = HISTORY_PATH
     chat.EVALUATOR.history_path = original_eval_path
 

--- a/tests/test_ui/test_transparency.py
+++ b/tests/test_ui/test_transparency.py
@@ -1,0 +1,36 @@
+import gradio as gr
+from gradio.events import EventData
+
+from src.ui.components.transparency import (
+    CitationBadge,
+    DetailsDrawer,
+    TransparencyPanel,
+)
+
+
+def test_citation_badge_click_returns_label():
+    badge = CitationBadge("Doc1")
+    evt = EventData(_data={}, target="Doc1")
+    assert badge.on_click(evt) == "Doc1"
+
+
+def test_details_drawer_toggle():
+    drawer = DetailsDrawer()
+    evt = EventData(_data={}, target=None)
+    assert drawer.toggle(evt) is True
+    assert drawer.toggle(evt) is False
+
+
+def test_transparency_panel_update_renders_metadata():
+    with gr.Blocks():
+        panel = TransparencyPanel().render()
+        panel.bind()
+    meta = {
+        "citations": [{"label": "Doc1"}],
+        "latency": 12.3,
+        "details": {"a": 1},
+    }
+    updates = panel.update(meta)
+    assert "Doc1" in updates[0]["value"]
+    assert "Latency" in updates[1]["value"]
+    assert updates[2]["value"] == meta["details"]


### PR DESCRIPTION
## Description:
- add transparency components (citation badge, drawer, performance indicator) with responsive styles
- integrate panel in chat interface using retrieval metadata
- add unit tests leveraging Gradio EventData

## Testing Done:
- `flake8 src/ tests/ app.py`
- `mypy src/ app.py` *(fails: missing stubs for rank_bm25, nltk.stem, yaml; type errors in document_service)*
- `python -m pytest tests/ -v`

## Performance Impact:
- N/A

## Configuration Changes:
- None

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bc701b3de483228dffab1752e0e030