### PR TITLE
feat(ui): add ranking controls component

### DIFF
--- a/src/ui/components/ranking_controls.py
+++ b/src/ui/components/ranking_controls.py
@@ -1,0 +1,85 @@
+"""Controls for tuning ranking parameters in the chat interface."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+import gradio as gr
+
+
+@dataclass
+class RankingControls:
+    """Grouped sliders and toggle for ranking parameters."""
+
+    rrf_k: int = 60
+    w_dense: float = 1.0
+    w_lexical: float = 1.0
+    enable_rerank: bool = False
+
+    def __post_init__(self) -> None:
+        self.state = gr.State(
+            {
+                "rrf_k": self.rrf_k,
+                "w_dense": self.w_dense,
+                "w_lexical": self.w_lexical,
+                "enable_rerank": self.enable_rerank,
+            }
+        )
+
+    def render(self) -> "RankingControls":
+        with gr.Accordion("Ranking", open=False):
+            self.rrf_k_slider = gr.Slider(
+                minimum=1,
+                maximum=100,
+                step=1,
+                value=self.rrf_k,
+                label="RRF k",
+            )
+            self.w_dense_slider = gr.Slider(
+                minimum=0.0,
+                maximum=2.0,
+                step=0.1,
+                value=self.w_dense,
+                label="w_dense",
+            )
+            self.w_lexical_slider = gr.Slider(
+                minimum=0.0,
+                maximum=2.0,
+                step=0.1,
+                value=self.w_lexical,
+                label="w_lexical",
+            )
+            self.rerank_toggle = gr.Checkbox(
+                value=self.enable_rerank, label="Enable Rerank"
+            )
+        return self
+
+    def bind(self) -> None:
+        components = [
+            self.rrf_k_slider,
+            self.w_dense_slider,
+            self.w_lexical_slider,
+            self.rerank_toggle,
+        ]
+        for comp in components:
+            comp.change(
+                self.update_state,
+                inputs=components,
+                outputs=self.state,
+            )
+
+    def update_state(
+        self, rrf_k: int, w_dense: float, w_lexical: float, enable_rerank: bool
+    ) -> Dict[str, Any]:
+        """Validate and persist ranking parameters."""
+        rrf_k = int(max(1, min(100, rrf_k)))
+        w_dense = float(max(0.0, min(2.0, w_dense)))
+        w_lexical = float(max(0.0, min(2.0, w_lexical)))
+        enable_rerank = bool(enable_rerank)
+        return {
+            "rrf_k": rrf_k,
+            "w_dense": w_dense,
+            "w_lexical": w_lexical,
+            "enable_rerank": enable_rerank,
+        }

--- a/src/ui/settings.py
+++ b/src/ui/settings.py
@@ -1,6 +1,7 @@
 import gradio as gr
 
 from .navbar import render_navbar
+from .components.ranking_controls import RankingControls
 
 
 def settings_page() -> gr.Blocks:
@@ -8,4 +9,6 @@ def settings_page() -> gr.Blocks:
     with gr.Blocks() as demo:
         render_navbar()
         gr.Markdown("# Settings")
+        controls = RankingControls().render()
+        controls.bind()
     return demo

--- a/tests/test_ui/test_ranking_controls.py
+++ b/tests/test_ui/test_ranking_controls.py
@@ -1,0 +1,23 @@
+import gradio as gr
+from src.ui.components.ranking_controls import RankingControls
+
+
+def test_ranking_controls_update_state():
+    with gr.Blocks():
+        controls = RankingControls().render()
+        controls.bind()
+    state = controls.update_state(70, 1.5, 0.5, True)
+    assert state["rrf_k"] == 70
+    assert state["w_dense"] == 1.5
+    assert state["w_lexical"] == 0.5
+    assert state["enable_rerank"] is True
+
+
+def test_ranking_controls_validation_clamps_values():
+    with gr.Blocks():
+        controls = RankingControls().render()
+    state = controls.update_state(0, -1.0, 3.0, False)
+    assert state["rrf_k"] == 1
+    assert state["w_dense"] == 0.0
+    assert state["w_lexical"] == 2.0
+    assert state["enable_rerank"] is False


### PR DESCRIPTION
## Description:
- add ranking controls component with sliders and rerank toggle
- wire controls into settings page
- cover state updates with unit tests

## Testing Done:
- `flake8 src/ui/components/ranking_controls.py src/ui/settings.py tests/test_ui/test_ranking_controls.py`
- `mypy src/ app.py` *(fails: missing stubs for rank_bm25, nltk)*
- `python -m pytest tests/ -v`
- `python -m pytest tests/test_ui/test_ranking_controls.py -v`
- `pip install types-PyYAML`

## Performance Impact:
- N/A (UI-only change)

## Configuration Changes:
- none

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bc71f6548c8322a9262b1b0dbb71c2