### PR TITLE
feat(ui): add evaluation dashboard

### DIFF
--- a/src/evaluation/ragas_integration.py
+++ b/src/evaluation/ragas_integration.py
@@ -6,7 +6,7 @@ import json
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, List
+from typing import Any, List, Optional
 
 from ragas import evaluate
 from ragas.metrics import faithfulness
@@ -63,3 +63,24 @@ class RagasEvaluator:
         with self.history_path.open("a", encoding="utf-8") as file:
             file.write(json.dumps(record.__dict__) + "\n")
         return record
+
+    def load_history(
+        self,
+        start: Optional[datetime] = None,
+        end: Optional[datetime] = None,
+    ) -> List[EvaluationResult]:
+        """Load evaluation history filtered by optional time range."""
+        if not self.history_path.exists():
+            return []
+        records: List[EvaluationResult] = []
+        with self.history_path.open("r", encoding="utf-8") as file:
+            for line in file:
+                data = json.loads(line)
+                record = EvaluationResult(**data)
+                ts = datetime.fromisoformat(record.timestamp)
+                if start and ts < start:
+                    continue
+                if end and ts > end:
+                    continue
+                records.append(record)
+        return records

--- a/src/ui/evaluate.py
+++ b/src/ui/evaluate.py
@@ -1,6 +1,78 @@
-import gradio as gr
+"""Evaluation dashboard page."""
 
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Tuple, Dict, Any
+
+import gradio as gr
+import pandas as pd
+import plotly.express as px
+
+from src.evaluation.ragas_integration import EvaluationResult, RagasEvaluator
 from .navbar import render_navbar
+
+EVALUATOR = RagasEvaluator()
+
+
+def _history_to_df(history: List[EvaluationResult]) -> pd.DataFrame:
+    """Convert history records to a DataFrame."""
+    if not history:
+        return pd.DataFrame(
+            columns=[
+                "timestamp",
+                "query",
+                "score",
+                "rationale",
+            ]
+        )
+    return pd.DataFrame([h.__dict__ for h in history])
+
+
+def _load_dashboard(
+    start: str | None,
+    end: str | None,
+) -> Tuple[
+    str,
+    Any,
+    pd.DataFrame,
+    str,
+    Dict[str, Any],
+    Dict[str, Any],
+]:
+    """Prepare dashboard data for the given time range."""
+    start_dt = datetime.fromisoformat(start) if start else None
+    end_dt = datetime.fromisoformat(end) if end else None
+    history = EVALUATOR.load_history(start_dt, end_dt)
+    df = _history_to_df(history)
+    if df.empty:
+        fig = px.line(title="No data")
+        summary = "No evaluations available"
+        alerts = "No alerts"
+        empty = gr.update(visible=False)
+        return summary, fig, df, alerts, empty, empty
+
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    avg_score = df["score"].mean()
+    summary = f"**Evaluations:** {len(df)}  |  **Avg Score:** {avg_score:.2f}"
+    fig = px.line(df, x="timestamp", y="score", title="Faithfulness Over Time")
+    alerts_df = df[df["score"] < 0.7][["timestamp", "query", "score"]]
+    if alerts_df.empty:
+        alerts = "No alerts"
+    else:
+        alerts = alerts_df.to_string(index=False)
+    csv_bytes = df.to_csv(index=False).encode("utf-8")
+    json_bytes = df.to_json(orient="records").encode("utf-8")
+    csv_update = gr.update(value=csv_bytes, visible=True)
+    json_update = gr.update(value=json_bytes, visible=True)
+    return (
+        summary,
+        fig,
+        df[["timestamp", "query", "score", "rationale"]],
+        alerts,
+        csv_update,
+        json_update,
+    )
 
 
 def evaluate_page() -> gr.Blocks:
@@ -8,4 +80,38 @@ def evaluate_page() -> gr.Blocks:
     with gr.Blocks() as demo:
         render_navbar()
         gr.Markdown("# Evaluate")
+        with gr.Row():
+            start_date = gr.Textbox(
+                label="Start Date",
+                placeholder="YYYY-MM-DD",
+            )
+            end_date = gr.Textbox(
+                label="End Date",
+                placeholder="YYYY-MM-DD",
+            )
+            load_btn = gr.Button("Load", variant="primary")
+
+        summary = gr.Markdown()
+        chart = gr.Plot()
+        analysis = gr.DataFrame(label="Query Analysis")
+        alerts_box = gr.Markdown(label="Quality Alerts")
+        with gr.Row():
+            export_csv = gr.DownloadButton("Export CSV", visible=False)
+            export_json = gr.DownloadButton("Export JSON", visible=False)
+
+        load_btn.click(
+            _load_dashboard,
+            inputs=[start_date, end_date],
+            outputs=[
+                summary,
+                chart,
+                analysis,
+                alerts_box,
+                export_csv,
+                export_json,
+            ],
+        )
     return demo
+
+
+__all__ = ["evaluate_page", "_load_dashboard", "EVALUATOR"]

--- a/tests/test_ui/test_evaluate.py
+++ b/tests/test_ui/test_evaluate.py
@@ -1,0 +1,56 @@
+"""Tests for the evaluation dashboard UI."""
+
+from datetime import datetime, timedelta
+
+import gradio as gr
+
+from src.evaluation.ragas_integration import EvaluationResult
+from src.ui.evaluate import EVALUATOR, _load_dashboard, evaluate_page
+
+
+def test_evaluate_page_has_components():
+    page = evaluate_page()
+    blocks = list(page.blocks.values())
+    assert any(isinstance(b, gr.Plot) for b in blocks)
+    assert any(isinstance(b, gr.DataFrame) for b in blocks)
+    assert any(isinstance(b, gr.DownloadButton) for b in blocks)
+
+
+def test_load_dashboard_filters_and_exports(monkeypatch):
+    now = datetime.utcnow()
+    records = [
+        EvaluationResult(
+            timestamp=(now - timedelta(days=1)).isoformat(),
+            query="q1",
+            answer="a1",
+            contexts=[],
+            score=0.6,
+            rationale="r1",
+        ),
+        EvaluationResult(
+            timestamp=now.isoformat(),
+            query="q2",
+            answer="a2",
+            contexts=[],
+            score=0.9,
+            rationale="r2",
+        ),
+    ]
+
+    captured = {}
+
+    def fake_load(start, end):
+        captured["start"] = start
+        captured["end"] = end
+        return records
+
+    monkeypatch.setattr(EVALUATOR, "load_history", fake_load)
+    summary, fig, df, alerts, csv_update, json_update = _load_dashboard(
+        "2020-01-01", None
+    )
+    assert isinstance(captured["start"], datetime)
+    assert "Evaluations" in summary
+    assert len(df) == 2
+    assert csv_update["value"].startswith(b"timestamp")
+    assert json_update["value"].startswith(b"[")
+    assert "q1" in alerts


### PR DESCRIPTION
## Description:
- overhaul evaluation page with historical metrics, charts, query analysis, quality alerts, and data export
- load metric history with optional time-range filtering
- add UI tests covering dashboard behaviour

## Testing Done:
- `flake8 src/ tests/ app.py`
- `python -m pytest tests/ -v`
- `python -m src.config.validate config/default_settings.yaml`
- `mypy src/ui/evaluate.py src/evaluation/ragas_integration.py app.py` *(fails: command produced no output)*

## Performance Impact:
- None

## Configuration Changes:
- None

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bc75f39e6083228b991b58627f18cf