### PR TITLE
feat(ui): tabbed settings with YAML persistence

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from tempfile import NamedTemporaryFile
+from typing import Any, Dict, Optional, Tuple
 
 import yaml
 
 
 _logger = logging.getLogger(__name__)
+
+# Path to repository default configuration
+DEFAULT_CONFIG_PATH = (
+    Path(__file__).resolve().parents[2] / "config" / "default_settings.yaml"
+)
 
 
 def load_settings(path: str) -> Tuple[Dict[str, Any], Dict[str, Any]]:
@@ -30,3 +36,34 @@ def load_settings(path: str) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     except yaml.YAMLError as exc:  # pragma: no cover
         _logger.error("Invalid YAML configuration: %s", exc)
         return {}, {"error": "invalid_yaml", "path": path}
+
+
+def load_default_settings() -> Dict[str, Any]:
+    """Load repository default configuration."""
+    settings, _ = load_settings(str(DEFAULT_CONFIG_PATH))
+    return settings
+
+
+def save_settings(
+    settings: Dict[str, Any], path: Optional[str] = None
+) -> Dict[str, str]:
+    """Persist ``settings`` to ``path``.
+
+    If ``path`` is ``None`` a temporary file is created and its path returned
+    in the metadata. When saving fails, ``metadata`` contains an ``error``
+    field.
+    """
+    try:
+        if path is None:
+            handle = NamedTemporaryFile(delete=False, suffix=".yaml")
+            path = handle.name
+            with handle:
+                yaml.safe_dump(settings, handle)
+        else:
+            config_path = Path(path)
+            with config_path.open("w", encoding="utf-8") as handle:
+                yaml.safe_dump(settings, handle)
+        return {"path": str(path)}
+    except OSError as exc:  # pragma: no cover
+        _logger.error("Failed to save configuration: %s", exc)
+        return {"error": "write_failed", "path": str(path)}

--- a/src/ui/components/__init__.py
+++ b/src/ui/components/__init__.py
@@ -1,0 +1,3 @@
+"""UI component utilities."""
+
+__all__ = ["ranking_controls", "transparency"]

--- a/src/ui/settings.py
+++ b/src/ui/settings.py
@@ -1,14 +1,119 @@
+"""Settings page UI with real-time validation and YAML import/export."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
 import gradio as gr
 
+from src.config.settings import (
+    load_default_settings,
+    load_settings,
+    save_settings,
+)
+from src.config.validate import validate_settings
+
 from .navbar import render_navbar
-from .components.ranking_controls import RankingControls
 
 
 def settings_page() -> gr.Blocks:
-    """Build the settings page."""
+    """Build the settings page with tabbed layout."""
+    defaults = load_default_settings()
+
     with gr.Blocks() as demo:
         render_navbar()
         gr.Markdown("# Settings")
-        controls = RankingControls().render()
-        controls.bind()
+        settings_state = gr.State(defaults)
+
+        def update_field(
+            field: str, value: float, settings: Dict[str, Any]
+        ) -> Tuple[Dict[str, Any], str]:
+            new_settings = {**settings, field: value}
+            _, errors = validate_settings(new_settings)
+            return new_settings, errors.get(field, "")
+
+        def import_settings(file, settings: Dict[str, Any]):
+            if file is None:
+                return (
+                    settings,
+                    "",
+                    settings.get("top_k"),
+                    settings.get("rrf_k"),
+                )
+            new_settings, _ = load_settings(file.name)
+            valid, errors = validate_settings(new_settings)
+            if not valid:
+                return (
+                    settings,
+                    "Invalid configuration",
+                    settings.get("top_k"),
+                    settings.get("rrf_k"),
+                )
+            return (
+                new_settings,
+                "",
+                new_settings.get("top_k"),
+                new_settings.get("rrf_k"),
+            )
+
+        def reset_defaults():
+            return defaults, "", defaults.get("top_k"), defaults.get("rrf_k")
+
+        def export_settings_cb(settings: Dict[str, Any]):
+            meta = save_settings(settings)
+            return meta.get("path")
+
+        with gr.Tabs():
+            with gr.Tab("Retrieval"):
+                top_k = gr.Number(
+                    label="Top K", value=defaults.get("top_k", 5)
+                )
+                top_k_error = gr.Markdown()
+                rrf_k = gr.Number(
+                    label="RRF k", value=defaults.get("rrf_k", 60)
+                )
+                rrf_k_error = gr.Markdown()
+
+                top_k.change(
+                    lambda v, s: update_field("top_k", v, s),
+                    inputs=[top_k, settings_state],
+                    outputs=[settings_state, top_k_error],
+                )
+                rrf_k.change(
+                    lambda v, s: update_field("rrf_k", v, s),
+                    inputs=[rrf_k, settings_state],
+                    outputs=[settings_state, rrf_k_error],
+                )
+
+            with gr.Tab("Models"):
+                gr.Markdown("Model settings coming soon.")
+
+            with gr.Tab("Performance"):
+                gr.Markdown("Performance settings coming soon.")
+
+            with gr.Tab("Advanced"):
+                status = gr.Markdown()
+                import_file = gr.File(
+                    label="Import YAML", file_types=[".yaml", ".yml"]
+                )
+                export_file = gr.File(label="Exported YAML", interactive=False)
+                export_btn = gr.Button("Export YAML")
+                reset_btn = gr.Button("Reset to defaults")
+
+                import_file.change(
+                    import_settings,
+                    inputs=[import_file, settings_state],
+                    outputs=[settings_state, status, top_k, rrf_k],
+                )
+                reset_btn.click(
+                    reset_defaults,
+                    inputs=None,
+                    outputs=[settings_state, status, top_k, rrf_k],
+                )
+                export_btn.click(
+                    export_settings_cb,
+                    inputs=settings_state,
+                    outputs=export_file,
+                )
+
     return demo

--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
-from src.config.settings import load_settings
+from src.config.settings import (
+    load_default_settings,
+    load_settings,
+    save_settings,
+)
 
 
 def test_load_settings(tmp_path: Path) -> None:
@@ -18,3 +22,18 @@ def test_missing_file() -> None:
     settings, meta = load_settings("nonexistent.yaml")
     assert settings == {}
     assert meta["error"] == "file_not_found"
+
+
+def test_save_and_load_roundtrip(tmp_path: Path) -> None:
+    data = {"top_k": 10, "rrf_k": 60}
+    config_file = tmp_path / "config.yaml"
+    meta = save_settings(data, str(config_file))
+    assert "error" not in meta
+    loaded, _ = load_settings(meta["path"])
+    assert loaded == data
+
+
+def test_load_default_settings() -> None:
+    defaults = load_default_settings()
+    assert defaults["top_k"] == 5
+    assert defaults["rrf_k"] == 60

--- a/tests/test_config/test_validate.py
+++ b/tests/test_config/test_validate.py
@@ -12,3 +12,9 @@ def test_validate_settings_errors() -> None:
     assert valid is False
     assert errors["top_k"].startswith("out_of_bounds")
     assert errors["rrf_k"] == "not_numeric"
+
+
+def test_validate_settings_missing() -> None:
+    valid, errors = validate_settings({})
+    assert valid is False
+    assert errors["top_k"] == "missing"


### PR DESCRIPTION
## Description:
- replace settings page with tabbed layout and real-time validation
- add YAML import/export, reset-to-default, and config persistence helpers
- test configuration validation and roundtrip persistence

## Testing Done:
- `flake8 src/ tests/ app.py`
- `mypy src/ app.py` *(fails: mypy.ini: Source contains parsing errors: 'mypy.ini' [line 21]: ')\n')*
- `python -m src.config.validate config/default_settings.yaml`
- `pytest tests/ -v`

## Performance Impact:
- N/A

## Configuration Changes:
- add default loading and save functions for YAML settings

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bc7cd0410c8322bd2fffd5854ff534