### PR TITLE
improve(config): configure black and ruff for Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,15 @@ dev = [
 
 [tool.black]
 line-length = 90
-target-version = ["py311"]  # adjust to your floor; optional
+target-version = ["py312"]  # adjust to your floor; optional
+
+[tool.ruff]
+target-version = "py312"
+line-length = 90
+
+[tool.ruff.lint]
+select = ["E", "F", "B"]
+ignore = ["E402", "E501"]
 
 [tool.flake8]               # Flake8 ≥ 7.0 supports pyproject
 max-line-length = 90

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -44,9 +44,7 @@ def load_default_settings() -> Dict[str, Any]:
     return settings
 
 
-def save_settings(
-    settings: Dict[str, Any], path: Optional[str] = None
-) -> Dict[str, str]:
+def save_settings(settings: Dict[str, Any], path: Optional[str] = None) -> Dict[str, str]:
     """Persist ``settings`` to ``path``.
 
     If ``path`` is ``None`` a temporary file is created and its path returned

--- a/src/evaluation/ragas_integration.py
+++ b/src/evaluation/ragas_integration.py
@@ -33,9 +33,7 @@ class RagasEvaluator:
         self.history_path = Path(history_path)
         self.history: List[EvaluationResult] = []
 
-    def evaluate(
-        self, query: str, answer: str, contexts: List[str]
-    ) -> EvaluationResult:
+    def evaluate(self, query: str, answer: str, contexts: List[str]) -> EvaluationResult:
         """Evaluate an answer's faithfulness against contexts."""
         data = {
             "question": [query],

--- a/src/integrations/huggingface_models.py
+++ b/src/integrations/huggingface_models.py
@@ -16,9 +16,7 @@ class HuggingFaceModelManager:
     def __init__(self, cache_dir: Optional[str] = None) -> None:
         self._logger = logging.getLogger(__name__)
         self.cache_dir = Path(
-            cache_dir
-            or os.getenv("HF_HOME")
-            or (Path.home() / ".cache" / "huggingface")
+            cache_dir or os.getenv("HF_HOME") or (Path.home() / ".cache" / "huggingface")
         )
         if snapshot_download is None:  # pragma: no cover
             message = f"huggingface_hub library missing: {_import_error}"

--- a/src/integrations/pinecone_client.py
+++ b/src/integrations/pinecone_client.py
@@ -53,9 +53,7 @@ class PineconeClient:
                 return func(*args, **kwargs)
             except Exception as exc:  # pragma: no cover
                 if attempt == MAX_RETRIES - 1:
-                    self._logger.error(
-                        "Operation failed after %s attempts", MAX_RETRIES
-                    )
+                    self._logger.error("Operation failed after %s attempts", MAX_RETRIES)
                     raise
                 self._logger.warning(
                     "Operation failed (%s/%s): %s",

--- a/src/query_service.py
+++ b/src/query_service.py
@@ -24,9 +24,7 @@ class QueryService:
     ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
         retrieval_mode = mode or self.default_mode
         with PerformanceTracker() as perf:
-            results, meta = self.retriever.query(
-                query, mode=retrieval_mode, top_k=top_k
-            )
+            results, meta = self.retriever.query(query, mode=retrieval_mode, top_k=top_k)
         metrics = perf.metrics()
         meta.update(metrics)
         self.dashboard.log(metrics)

--- a/src/ranking/reranker.py
+++ b/src/ranking/reranker.py
@@ -24,10 +24,8 @@ class CrossEncoderReranker:
         self.executor = ThreadPoolExecutor(max_workers=1)
         if load_model:
             self.tokenizer = AutoTokenizer.from_pretrained(model_name)
-            self.model = (
-                AutoModelForSequenceClassification.from_pretrained(  # noqa: E501
-                    model_name
-                )
+            self.model = AutoModelForSequenceClassification.from_pretrained(  # noqa: E501
+                model_name
             )
             self.model.to("cpu")
         else:  # pragma: no cover - used in tests to avoid heavy model load
@@ -97,7 +95,10 @@ class CrossEncoderReranker:
             }
 
         ranked = sorted(
-            ({**doc, "score": score} for doc, score in zip(top_docs, scores)),
+            (
+                {**doc, "score": score}
+                for doc, score in zip(top_docs, scores, strict=False)
+            ),
             key=lambda x: x["score"],
             reverse=True,
         )

--- a/src/retrieval/dense.py
+++ b/src/retrieval/dense.py
@@ -61,6 +61,7 @@ class DenseRetriever:
                     ids,
                     embeddings,
                     metadatas,
+                    strict=False,
                 )
             ]
             self.pinecone_client.upsert_embeddings(self.index_name, vectors)
@@ -84,9 +85,7 @@ class DenseRetriever:
         """Query the Pinecone index with a text string."""
         try:
             embedding, _ = self.embed_query(query)
-            response = self.pinecone_client.query(
-                self.index_name, embedding, top_k=top_k
-            )
+            response = self.pinecone_client.query(self.index_name, embedding, top_k=top_k)
             matches = getattr(response, "matches", [])
             results = [(m["id"], m["score"]) for m in matches]
             return results, {"retrieved": len(results)}

--- a/src/retrieval/hybrid.py
+++ b/src/retrieval/hybrid.py
@@ -88,7 +88,7 @@ class HybridRetriever:
             text_lookup = {
                 doc_id: text
                 for doc_id, text in zip(  # noqa: E501
-                    self.lexical.doc_ids, self.lexical.documents
+                    self.lexical.doc_ids, self.lexical.documents, strict=False
                 )
             }
         for doc in merged:

--- a/src/retrieval/lexical.py
+++ b/src/retrieval/lexical.py
@@ -77,7 +77,7 @@ class LexicalBM25:
             tokens = self._preprocess(query)
             scores = self.bm25.get_scores(tokens)
             ranked = sorted(
-                zip(self.doc_ids, scores), key=lambda x: x[1], reverse=True
+                zip(self.doc_ids, scores, strict=False), key=lambda x: x[1], reverse=True
             )[:top_k]
             return ranked, {"retrieved": len(ranked)}
         except Exception as exc:  # pragma: no cover

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -25,9 +25,7 @@ class DocumentService:
         self.lexical_retriever = lexical_retriever
         self.chunk_size = chunk_size
         self.overlap = overlap
-        self.index_management = IndexManagement(
-            dense_retriever, lexical_retriever
-        )
+        self.index_management = IndexManagement(dense_retriever, lexical_retriever)
         self.dashboard = dashboard or MetricsDashboard()
 
     # Parsing helpers
@@ -40,14 +38,10 @@ class DocumentService:
                 try:
                     from pypdf import PdfReader
                 except Exception as exc:  # pragma: no cover
-                    raise RuntimeError(
-                        "pypdf is required for PDF parsing"
-                    ) from exc
+                    raise RuntimeError("pypdf is required for PDF parsing") from exc
                 with path.open("rb") as fh:
                     reader = PdfReader(fh)
-                    text = "\n".join(
-                        page.extract_text() or "" for page in reader.pages
-                    )
+                    text = "\n".join(page.extract_text() or "" for page in reader.pages)
             elif suffix == ".docx":
                 try:
                     from docx import Document  # type: ignore
@@ -124,9 +118,7 @@ class DocumentService:
             dense_ids, dense_meta = self.dense_retriever.index_corpus(
                 all_chunks, metadatas
             )
-            lexical_ids, lexical_meta = self.lexical_retriever.index_documents(
-                all_chunks
-            )
+            lexical_ids, lexical_meta = self.lexical_retriever.index_documents(all_chunks)
         metrics = perf.metrics()
         self.dashboard.log({"operation": "ingest", **metrics})
         return {
@@ -146,9 +138,7 @@ class DocumentService:
         """Delegate document deletion to index management."""
         return self.index_management.delete_document(doc_id)
 
-    def bulk_operations(
-        self, operations: List[Dict[str, Any]]
-    ) -> Dict[str, Any]:
+    def bulk_operations(self, operations: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Delegate bulk operations to index management."""
         return self.index_management.bulk_operations(operations)
 

--- a/tests/test_integrations/test_pinecone_client.py
+++ b/tests/test_integrations/test_pinecone_client.py
@@ -55,9 +55,7 @@ def test_create_index_retries(monkeypatch):
         create_index=fake_create_index,
         delete_index=lambda name: None,
         Index=lambda name: FakeIndex(),
-        describe_index=lambda name: types.SimpleNamespace(
-            dimension=EMBEDDING_DIMENSION
-        ),
+        describe_index=lambda name: types.SimpleNamespace(dimension=EMBEDDING_DIMENSION),
     )
     monkeypatch.setattr(pinecone_client, "pinecone", fake_pinecone)
 
@@ -81,9 +79,7 @@ def test_delete_index_retries(monkeypatch):
         delete_index=fake_delete_index,
         Index=lambda name: FakeIndex(),
         create_index=lambda **kwargs: None,
-        describe_index=lambda name: types.SimpleNamespace(
-            dimension=EMBEDDING_DIMENSION
-        ),
+        describe_index=lambda name: types.SimpleNamespace(dimension=EMBEDDING_DIMENSION),
     )
     monkeypatch.setattr(pinecone_client, "pinecone", fake_pinecone)
 
@@ -98,9 +94,7 @@ def test_upsert_batches_and_retries(monkeypatch):
     fake_pinecone = types.SimpleNamespace(
         init=lambda api_key=None, environment=None: None,
         Index=lambda name: index,
-        describe_index=lambda name: types.SimpleNamespace(
-            dimension=EMBEDDING_DIMENSION
-        ),
+        describe_index=lambda name: types.SimpleNamespace(dimension=EMBEDDING_DIMENSION),
         list_indexes=lambda: [],
         create_index=lambda **kwargs: None,
         delete_index=lambda name: None,
@@ -132,9 +126,7 @@ def test_query_retries(monkeypatch):
     fake_pinecone = types.SimpleNamespace(
         init=lambda api_key=None, environment=None: None,
         Index=lambda name: index,
-        describe_index=lambda name: types.SimpleNamespace(
-            dimension=EMBEDDING_DIMENSION
-        ),
+        describe_index=lambda name: types.SimpleNamespace(dimension=EMBEDDING_DIMENSION),
         list_indexes=lambda: [],
         create_index=lambda **kwargs: None,
         delete_index=lambda name: None,

--- a/tests/test_ranking/test_reranker.py
+++ b/tests/test_ranking/test_reranker.py
@@ -42,9 +42,7 @@ def test_reranker_timeout_fallback(monkeypatch):
 
 def test_reranker_benchmark(benchmark):
     reranker = CrossEncoderReranker(load_model=False)
-    reranker._score_pairs = (
-        lambda q, texts: [0.0 for _ in texts]
-    )  # type: ignore
+    reranker._score_pairs = lambda q, texts: [0.0 for _ in texts]  # type: ignore
 
     def run():
         docs = _build_docs(["d1", "d2", "d3"])


### PR DESCRIPTION
## Description:
- set Black target version to Python 3.12
- add Ruff configuration targeting Python 3.12 with basic lint selections
- run black and ruff --fix to update code style

## Testing Done:
- `ruff check --fix .`
- `black src/ tests/ app.py`
- `python -m pytest tests/ -v`

## Performance Impact:
- None

## Configuration Changes:
- tool.black.target-version set to py312
- new tool.ruff section with lint rules and ignore list

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bc8ed2b6248322895197d3d0d92b4e