### PR TITLE
docs: update setup for Python 3.12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ The application follows a modular Python architecture with clear separation of c
 
 ## Development Environment & Commands
 
-The application is built using Python 3.8+ with Gradio 5 as the primary UI framework. All dependencies should already be installed in the environment.
+The application is built using Python 3.12 with Gradio 5 as the primary UI framework. All dependencies should already be installed in the environment.
 
 **Core Development Commands:**
 - To run the multipage application: `python app.py`

--- a/FRD.md
+++ b/FRD.md
@@ -740,7 +740,7 @@ User Query → Retrieval Engine → RRF Fusion → [Optional Reranking] → LLM 
 #### CON-TECH-002: External Dependencies
 - **Pinecone vector database required**
 - **Internet connectivity for model downloads**
-- **Python 3.8+ runtime environment**
+- **Python 3.12 runtime environment**
 
 ### 7.2 Business Constraints
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A hybrid retrieval-augmented generation platform combining dense vector search a
 
 ### Tech Stack
 
-- **Backend**: Python 3.8+, FastAPI, Gradio 5
+- **Backend**: Python 3.12, FastAPI, Gradio 5
 - **ML/AI**: Sentence-Transformers, HuggingFace Transformers, Ragas
 - **Search**: Pinecone (vector), rank-bm25 (lexical)
 - **Testing**: pytest, pytest-asyncio, pytest-cov
@@ -78,17 +78,21 @@ The user interface provides four main workflows: querying the knowledge base, in
 
 ### Prerequisites
 
-- Python 3.8+ [[EVID: requirements.txt:1-48 | Python dependencies specified]]
+- Python 3.12 [[EVID: requirements.txt:1-48 | Python dependencies specified]]
 - Pinecone API account and API key
 - 8GB+ RAM for model loading
 
 ### Setup
 
-1. **Clone and install dependencies**:
+1. **Clone and set up the environment**:
 ```bash
 git clone <repository-url>
 cd personal-rag-copilot
-pip install pip-tools
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install setuptools wheel pip-tools
+pip-compile requirements.in  # generates requirements.txt
 pip-sync requirements.txt
 ```
 
@@ -167,8 +171,12 @@ personal-rag-copilot/
 ### Environment Setup
 
 ```bash
-# Install development dependencies
-pip install pip-tools
+# Create virtual environment
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install setuptools wheel pip-tools
+pip-compile requirements.in  # generates requirements.txt
 pip-sync requirements.txt
 
 # Run tests with coverage


### PR DESCRIPTION
## Description:
- document Python 3.12 as the required runtime
- clarify virtualenv creation and dependency locking workflow

## Testing Done:
- `python -m pytest tests/ -v`
- `python scripts/validate_rrf.py` *(fails: No such file or directory)*
- `python scripts/benchmark_retrieval.py` *(fails: No such file or directory)*
- `python scripts/validate_pinecone.py` *(fails: No such file or directory)*
- `python scripts/test_ui_routing.py` *(fails: No such file or directory)*

## Performance Impact:
- N/A

## Configuration Changes:
- document upgrade to Python 3.12

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bc92efc4388322ac0bf715b44ba79b