### PR TITLE
feat(config): add device and precision defaults

### DIFF
--- a/config/default_settings.yaml
+++ b/config/default_settings.yaml
@@ -1,2 +1,7 @@
 top_k: 5
 rrf_k: 60
+
+# Compute device selection: auto chooses best available
+device_preference: auto  # auto, cpu, gpu_openvino, gpu_xpu
+# Numerical precision for inference and retrieval operations
+precision: fp32          # fp32, fp16, int8

--- a/src/config/validate.py
+++ b/src/config/validate.py
@@ -6,7 +6,7 @@ import argparse
 import logging
 from typing import Any, Dict, Tuple
 
-from .settings import load_settings
+from .settings import load_settings, validate_options
 
 _logger = logging.getLogger(__name__)
 
@@ -30,6 +30,7 @@ def validate_settings(settings: Dict[str, Any]) -> Tuple[bool, Dict[str, str]]:
             continue
         if not low <= value <= high:
             errors[key] = f"out_of_bounds:{low}-{high}"
+    errors.update(validate_options(settings))
     return not errors, errors
 
 


### PR DESCRIPTION
## Description:
- add device_preference and precision to default settings with documentation
- validate new enumerated options when loading configuration

## Testing Done:
- `python -m src.config.validate config/default_settings.yaml`
- `python -m pytest tests/ -v` *(fails: fixture 'benchmark' not found)*

## Performance Impact:
- no change expected

## Configuration Changes:
- added `device_preference` and `precision` defaults

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bc9a6bbaac832289dd983e20431af6