### PR TITLE
feat(ranking): add device and precision support to reranker

### DIFF
--- a/src/ranking/reranker.py
+++ b/src/ranking/reranker.py
@@ -14,6 +14,9 @@ class CrossEncoderReranker:
         model_name: str = "BAAI/bge-reranker-v2-m3",
         cache_ttl: int = 300,
         load_model: bool = True,
+        *,
+        device: str = "cpu",
+        precision: str | None = None,
     ) -> None:
         self.model_name = model_name
         self.cache_ttl = cache_ttl
@@ -22,18 +25,66 @@ class CrossEncoderReranker:
             Tuple[List[Dict[str, Any]], float],
         ] = {}
         self.executor = ThreadPoolExecutor(max_workers=1)
+        self.device = device
+        self.precision = precision
+        self._use_openvino = False
+
+        if self.device == "gpu_xpu" and not torch.xpu.is_available():
+            self.device = "cpu"  # pragma: no cover
+        if self.device == "gpu_openvino":
+            try:  # pragma: no cover - import check
+                from openvino.runtime import Core
+
+                self.core = Core()
+            except Exception:  # pragma: no cover - OpenVINO missing
+                self.device = "cpu"
+
         if load_model:
             self.tokenizer = AutoTokenizer.from_pretrained(model_name)
-            self.model = AutoModelForSequenceClassification.from_pretrained(  # noqa: E501
-                model_name
-            )
-            self.model.to("cpu")
+            if self.device == "gpu_openvino":  # pragma: no cover
+                properties: Dict[str, Any] = {}
+                if self.precision:
+                    hint = self.precision.upper()
+                    properties["INFERENCE_PRECISION_HINT"] = hint
+                self.model = self.core.compile_model(
+                    model_name,
+                    "GPU",
+                    properties,
+                )
+                self._use_openvino = True
+            else:
+                self.model = (
+                    AutoModelForSequenceClassification.from_pretrained(  # noqa: E501
+                        model_name
+                    )
+                )
+                target_device = "xpu" if self.device == "gpu_xpu" else "cpu"
+                self.model.to(target_device)
+                if precision:
+                    dtype_map = {
+                        "fp16": torch.float16,
+                        "bf16": torch.bfloat16,
+                        "fp32": torch.float32,
+                    }
+                    dtype = dtype_map.get(precision, torch.float32)
+                    self.model.to(dtype=dtype)
         else:  # pragma: no cover - used in tests to avoid heavy model load
             self.tokenizer = None  # type: ignore
             self.model = None  # type: ignore
 
     def _score_pairs(self, query: str, texts: List[str]) -> List[float]:
         """Return relevance scores for query-document pairs."""
+        if self._use_openvino:
+            inputs = self.tokenizer(
+                [query] * len(texts),
+                texts,
+                padding=True,
+                truncation=True,
+                return_tensors="np",
+            )
+            result = self.model(inputs)
+            logits = next(iter(result.values())).squeeze(-1)
+            return logits.tolist()
         inputs = self.tokenizer(
             [query] * len(texts),
             texts,
@@ -41,9 +92,11 @@ class CrossEncoderReranker:
             truncation=True,
             return_tensors="pt",
         )
+        if self.device == "gpu_xpu":  # pragma: no cover - requires XPU
+            inputs = {k: v.to("xpu") for k, v in inputs.items()}
         with torch.no_grad():
             logits = self.model(**inputs).logits.squeeze(-1)
-        return logits.tolist()
+        return logits.cpu().tolist()
 
     def rerank(
         self,


### PR DESCRIPTION
## Description:
- extend `CrossEncoderReranker` with `device` and `precision` options and GPU fallbacks
- enable OpenVINO GPU inference and XPU model loading
- allow numpy-based scoring and add device fallback tests

## Testing Done:
- `black src/ tests/ app.py`
- `flake8 src/ranking/reranker.py tests/test_ranking/test_reranker.py` (repo-wide run reports pre-existing E501 warnings)
- `mypy src/ app.py` (fails: missing stubs and Python 3.10 union syntax in existing modules)
- `python -m pytest tests/ -v`

## Performance Impact:
- no change expected

## Configuration Changes:
- `CrossEncoderReranker` now accepts optional `device` and `precision` parameters

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bca5539a548322bea98011b8dff369