### PR TITLE
test(utils): add hardware detection tests

### DIFF
--- a/tests/test_utils/test_hardware.py
+++ b/tests/test_utils/test_hardware.py
@@ -1,30 +1,40 @@
 import sys
 import types
+import pytest
 
 from src.utils import hardware
 
 
-def test_has_openvino_gpu_true(monkeypatch):
+def mock_openvino(monkeypatch, devices):
     class DummyCore:
         def __init__(self):
-            self.available_devices = ["GPU.0"]
+            self.available_devices = devices
 
     runtime = types.SimpleNamespace(Core=DummyCore)
     openvino = types.SimpleNamespace(runtime=runtime)
     monkeypatch.setitem(sys.modules, "openvino", openvino)
     monkeypatch.setitem(sys.modules, "openvino.runtime", runtime)
+
+
+def mock_torch_xpu(monkeypatch, available: bool):
+    class DummyXPU:
+        @staticmethod
+        def is_available():
+            return available
+
+    torch_mod = types.SimpleNamespace(xpu=DummyXPU())
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+
+
+# --- availability checks ---------------------------------------------------
+
+def test_has_openvino_gpu_true(monkeypatch):
+    mock_openvino(monkeypatch, ["GPU.0"])
     assert hardware.has_openvino_gpu() is True
 
 
 def test_has_openvino_gpu_false_no_gpu(monkeypatch):
-    class DummyCore:
-        def __init__(self):
-            self.available_devices = ["CPU"]
-
-    runtime = types.SimpleNamespace(Core=DummyCore)
-    openvino = types.SimpleNamespace(runtime=runtime)
-    monkeypatch.setitem(sys.modules, "openvino", openvino)
-    monkeypatch.setitem(sys.modules, "openvino.runtime", runtime)
+    mock_openvino(monkeypatch, ["CPU"])
     assert hardware.has_openvino_gpu() is False
 
 
@@ -34,28 +44,32 @@ def test_has_openvino_gpu_false_missing(monkeypatch):
 
 
 def test_has_torch_xpu_true(monkeypatch):
-    class DummyXPU:
-        @staticmethod
-        def is_available():
-            return True
-
-    torch = types.SimpleNamespace(xpu=DummyXPU())
-    monkeypatch.setitem(sys.modules, "torch", torch)
+    mock_torch_xpu(monkeypatch, True)
     assert hardware.has_torch_xpu() is True
 
 
 def test_has_torch_xpu_false_missing(monkeypatch):
-    monkeypatch.setitem(sys.modules, "torch", None)
+    mock_torch_xpu(monkeypatch, False)
     assert hardware.has_torch_xpu() is False
 
 
-def test_detect_device_auto_prefers_xpu(monkeypatch):
-    monkeypatch.setattr(hardware, "has_torch_xpu", lambda: True)
-    monkeypatch.setattr(hardware, "has_openvino_gpu", lambda: False)
-    assert hardware.detect_device("auto") == "xpu"
+# --- device detection ------------------------------------------------------
 
-
-def test_detect_device_fallback_cpu(monkeypatch):
-    monkeypatch.setattr(hardware, "has_torch_xpu", lambda: False)
-    monkeypatch.setattr(hardware, "has_openvino_gpu", lambda: False)
-    assert hardware.detect_device("auto") == "cpu"
+@pytest.mark.parametrize(
+    "xpu_available, ov_devices, preference, expected",
+    [
+        (True, ["GPU.0"], "xpu", "xpu"),
+        (True, ["GPU.0"], "openvino", "openvino"),
+        (True, ["GPU.0"], "auto", "xpu"),
+        (False, ["GPU.0"], "xpu", "openvino"),
+        (True, [], "openvino", "xpu"),
+        (False, [], "auto", "cpu"),
+    ],
+)
+def test_detect_device(monkeypatch, xpu_available, ov_devices, preference, expected):
+    mock_torch_xpu(monkeypatch, xpu_available)
+    if ov_devices is not None:
+        mock_openvino(monkeypatch, ov_devices)
+    else:
+        monkeypatch.setitem(sys.modules, "openvino", None)
+    assert hardware.detect_device(preference) == expected


### PR DESCRIPTION
## Description:
- add utilities to mock `openvino.runtime.Core` and `torch.xpu.is_available`
- cover `detect_device` backend selection for different availability scenarios

## Testing Done:
- `python -m pytest tests/test_utils/test_hardware.py -v`
- `python -m pytest tests/ -v`

## Performance Impact:
- none

## Configuration Changes:
- none

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bca7e9deb08322925178c8c3f45906