### PR TITLE
feat(ui): surface retriever ranks and scores

### DIFF
--- a/tests/test_ui/test_transparency.py
+++ b/tests/test_ui/test_transparency.py
@@ -26,11 +26,13 @@ def test_transparency_panel_update_renders_metadata():
         panel = TransparencyPanel().render()
         panel.bind()
     meta = {
-        "citations": [{"label": "Doc1"}],
+        "citations": [{"label": "Doc1", "source": "dense"}],
+        "component_scores": {
+            "Doc1": {"dense": {"rank": 1, "score": 0.42, "snippet": "s"}}
+        },
         "latency": 12.3,
-        "details": {"a": 1},
     }
     updates = panel.update(meta)
-    assert "Doc1" in updates[0]["value"]
-    assert "Latency" in updates[1]["value"]
-    assert updates[2]["value"] == meta["details"]
+    assert 'title="Dense rank 1, score 0.42"' in updates[0]["value"]
+    assert updates[2]["value"][0]["rank"] == 1
+    assert updates[2]["value"][0]["score"] == 0.42


### PR DESCRIPTION
## Description:
- expand citation badges to show per-retriever rank and score tooltips
- populate transparency drawer with structured retriever details

## Testing Done:
- `flake8 src/ui/components/transparency.py tests/test_ui/test_transparency.py`
- `mypy src/ app.py`
- `python -m pytest tests/ -v`

## Performance Impact:
- No change expected.

## Configuration Changes:
- None.

## Evaluation Results:
- N/A


------
https://chatgpt.com/codex/tasks/task_e_68bcba7830f48322956cf38a6c3aaf7d