### PR TITLE
feat(ui): add bulk processing queue

### DIFF
--- a/tests/test_ui/test_ingest_queue.py
+++ b/tests/test_ui/test_ingest_queue.py
@@ -1,0 +1,32 @@
+from src.ui.ingest import _queue_files, _process_all, _document_service
+
+
+class DummyFile:
+    def __init__(self, name: str):
+        self.name = name
+
+
+def test_queue_and_process(tmp_path, monkeypatch):
+    file_path = tmp_path / "doc.txt"
+    file_path.write_text("hello world")
+
+    table, contents, _ = _queue_files([DummyFile(str(file_path))], [], {})
+    assert table[0][0] == "doc.txt"
+    assert table[0][2] == "pending"
+    assert "doc.txt" in contents
+
+    def fake_bulk_ops(operations):
+        assert operations[0]["action"] == "update"
+        return {
+            "results": [
+                {
+                    "action": "update",
+                    "result": {"status": "success"},
+                }
+            ]
+        }
+
+    monkeypatch.setattr(_document_service, "bulk_operations", fake_bulk_ops)
+    updated, report = _process_all(table, contents)
+    assert updated[0][2] == "success"
+    assert report["results"][0]["result"]["status"] == "success"


### PR DESCRIPTION
## Description:
- add queued file ingestion with bulk update/delete support
- show processing queue and completion report in ingest UI
- cover queue processing with unit test

## Testing Done:
- `black src/ tests/ app.py`
- `flake8 src/ tests/ app.py` *(fails: E501 line too long in existing files)*
- `mypy src/ app.py`
- `pytest tests/ -v`

## Performance Impact:
- no performance impact expected

## Configuration Changes:
- none

## Evaluation Results:
- not applicable


------
https://chatgpt.com/codex/tasks/task_e_68bcc40f00bc83228ea55c14047e8e10