### PR TITLE
feat(evaluation): add configurable metric thresholds

### DIFF
--- a/config/default_settings.yaml
+++ b/config/default_settings.yaml
@@ -5,3 +5,8 @@ rrf_k: 60
 device_preference: auto  # auto, cpu, gpu_openvino, gpu_xpu
 # Numerical precision for inference and retrieval operations
 precision: fp32          # fp32, fp16, int8
+
+evaluation_thresholds:
+  faithfulness: 0.7
+  relevancy: 0.7
+  precision: 0.7

--- a/src/config/runtime_config.py
+++ b/src/config/runtime_config.py
@@ -109,6 +109,17 @@ class ConfigManager:
         precision = os.getenv("PRECISION")
         if precision is not None:
             overrides["precision"] = precision.lower()
+        thresholds: Dict[str, Any] = {}
+        for metric in ["faithfulness", "relevancy", "precision"]:
+            env_key = f"EVAL_{metric.upper()}"
+            value = os.getenv(env_key)
+            if value is not None:
+                try:
+                    thresholds[metric] = float(value)
+                except ValueError:
+                    continue
+        if thresholds:
+            overrides["evaluation_thresholds"] = thresholds
         return overrides
 
     def as_dict(self) -> Dict[str, Any]:

--- a/src/config/validate.py
+++ b/src/config/validate.py
@@ -6,7 +6,7 @@ import argparse
 import logging
 from typing import Any, Dict, Tuple
 
-from .settings import load_settings, validate_options
+from .settings import load_settings, validate_options, validate_thresholds
 
 _logger = logging.getLogger(__name__)
 
@@ -31,6 +31,7 @@ def validate_settings(settings: Dict[str, Any]) -> Tuple[bool, Dict[str, str]]:
         if not low <= value <= high:
             errors[key] = f"out_of_bounds:{low}-{high}"
     errors.update(validate_options(settings))
+    errors.update(validate_thresholds(settings))
     return not errors, errors
 
 

--- a/tests/test_ui/test_evaluate.py
+++ b/tests/test_ui/test_evaluate.py
@@ -6,6 +6,7 @@ import gradio as gr
 
 from src.evaluation.ragas_integration import EvaluationResult
 from src.ui.evaluate import EVALUATOR, _load_dashboard, evaluate_page
+from src.config.runtime_config import config_manager
 
 
 def test_evaluate_page_has_components():
@@ -26,6 +27,9 @@ def test_load_dashboard_filters_and_exports(monkeypatch):
             contexts=[],
             score=0.6,
             rationale="r1",
+            faithfulness=0.6,
+            relevancy=0.9,
+            precision=0.9,
         ),
         EvaluationResult(
             timestamp=now.isoformat(),
@@ -34,6 +38,9 @@ def test_load_dashboard_filters_and_exports(monkeypatch):
             contexts=[],
             score=0.9,
             rationale="r2",
+            faithfulness=0.9,
+            relevancy=0.9,
+            precision=0.9,
         ),
     ]
 
@@ -54,3 +61,50 @@ def test_load_dashboard_filters_and_exports(monkeypatch):
     assert csv_update["value"].startswith(b"timestamp")
     assert json_update["value"].startswith(b"[")
     assert "q1" in alerts
+
+
+def test_alerts_use_thresholds(monkeypatch):
+    now = datetime.utcnow()
+    records = [
+        EvaluationResult(
+            timestamp=now.isoformat(),
+            query="q1",
+            answer="a1",
+            contexts=[],
+            score=0.8,
+            rationale="r1",
+            faithfulness=0.8,
+            relevancy=0.6,
+            precision=0.9,
+        ),
+        EvaluationResult(
+            timestamp=now.isoformat(),
+            query="q2",
+            answer="a2",
+            contexts=[],
+            score=0.6,
+            rationale="r2",
+            faithfulness=0.6,
+            relevancy=0.9,
+            precision=0.9,
+        ),
+    ]
+
+    monkeypatch.setattr(EVALUATOR, "load_history", lambda s, e: records)
+
+    thresholds = {"faithfulness": 0.7, "relevancy": 0.7, "precision": 0.7}
+    orig_get = config_manager.get
+
+    def fake_get(key, default=None):
+        if key == "evaluation_thresholds":
+            return thresholds
+        return orig_get(key, default)
+
+    monkeypatch.setattr(config_manager, "get", fake_get)
+
+    _, _, _, alerts, _, _ = _load_dashboard(None, None)
+    assert "q1" in alerts and "q2" in alerts
+
+    thresholds.update({"faithfulness": 0.5, "relevancy": 0.5, "precision": 0.5})
+    _, _, _, alerts, _, _ = _load_dashboard(None, None)
+    assert alerts == "No alerts"


### PR DESCRIPTION
## Description:
- add `evaluation_thresholds` to default settings with metrics for faithfulness, relevancy, and precision
- validate threshold values and allow environment overrides in config manager
- use configured thresholds to trigger evaluation alerts
- test dashboard alerts with multiple metrics and custom thresholds

## Testing Done:
- `black src/ tests/ app.py`
- `flake8 src/ tests/ app.py` *(fails: line too long errors in existing files)*
- `mypy src/config/settings.py src/config/validate.py src/config/runtime_config.py src/ui/evaluate.py tests/test_ui/test_evaluate.py` *(process interrupted)*
- `python -m src.config.validate config/default_settings.yaml`
- `python -m pytest tests/ -v` *(fails: tests/test_ranking/test_reranker.py::test_reranker_benchmark)*
- `python -m pytest tests/test_ui/test_evaluate.py -v`

## Performance Impact:
- None expected

## Configuration Changes:
- introduces `evaluation_thresholds` with default metric cutoffs (0.7)

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bccfd20d448322a4a999bd50a7774b