### PR TITLE
feat(evaluation): add recommendation engine

### DIFF
--- a/src/evaluation/recommendations.py
+++ b/src/evaluation/recommendations.py
@@ -1,0 +1,76 @@
+"""Generate evaluation recommendations and log their effectiveness."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+from src.config.runtime_config import config_manager
+
+
+def generate_recommendations(metrics: Dict[str, float]) -> List[str]:
+    """Generate improvement recommendations based on metric thresholds.
+
+    Args:
+        metrics: Mapping of metric name to score.
+
+    Returns:
+        A list of human-friendly recommendations.
+    """
+    thresholds = config_manager.get(
+        "evaluation_thresholds",
+        {"faithfulness": 0.7, "relevancy": 0.7, "precision": 0.7},
+    )
+    recs: List[str] = []
+    if metrics.get("relevancy", 1.0) < thresholds.get("relevancy", 0.7):
+        recs.append("Expand top-K")
+    if metrics.get("precision", 1.0) < thresholds.get("precision", 0.7):
+        recs.append("Enable reranking")
+    drop_count = sum(
+        metrics.get(name, 1.0) < thresholds.get(name, 0.7)
+        for name in ("faithfulness", "relevancy", "precision")
+    )
+    if drop_count > 1:
+        recs.append("Adjust weights")
+    return recs
+
+
+@dataclass
+class RecommendationRecord:
+    """Record of a recommendation and resulting metrics."""
+
+    recommendation: str
+    before: Dict[str, float]
+    after: Dict[str, float]
+
+
+class RecommendationLogger:
+    """Simple in-memory logger for recommendation effectiveness."""
+
+    def __init__(self) -> None:
+        self.records: List[RecommendationRecord] = []
+
+    def log(
+        self,
+        recommendation: str,
+        metrics_before: Dict[str, float],
+        metrics_after: Dict[str, float],
+    ) -> None:
+        self.records.append(
+            RecommendationRecord(
+                recommendation,
+                metrics_before,
+                metrics_after,
+            )
+        )
+
+    def get_records(self) -> List[RecommendationRecord]:
+        """Return all logged records."""
+        return list(self.records)
+
+
+__all__ = [
+    "generate_recommendations",
+    "RecommendationLogger",
+    "RecommendationRecord",
+]

--- a/tests/test_evaluation/test_recommendations.py
+++ b/tests/test_evaluation/test_recommendations.py
@@ -1,0 +1,62 @@
+from src.evaluation.recommendations import (
+    RecommendationLogger,
+    generate_recommendations,
+)
+from src.ui.evaluate import _load_dashboard, EVALUATOR
+from src.evaluation.ragas_integration import EvaluationResult
+
+
+def test_recommend_low_relevancy():
+    recs = generate_recommendations({"relevancy": 0.5, "precision": 0.9})
+    assert "Expand top-K" in recs
+    assert "Enable reranking" not in recs
+    assert "Adjust weights" not in recs
+
+
+def test_recommend_low_precision():
+    recs = generate_recommendations({"relevancy": 0.9, "precision": 0.6})
+    assert "Enable reranking" in recs
+    assert "Expand top-K" not in recs
+
+
+def test_recommend_cross_metric():
+    recs = generate_recommendations({"relevancy": 0.6, "precision": 0.6})
+    assert "Adjust weights" in recs
+    assert "Expand top-K" in recs
+    assert "Enable reranking" in recs
+
+
+def test_logger_records():
+    logger = RecommendationLogger()
+    before = {"relevancy": 0.5}
+    after = {"relevancy": 0.8}
+    logger.log("Expand top-K", before, after)
+    records = logger.get_records()
+    assert len(records) == 1
+    record = records[0]
+    assert record.recommendation == "Expand top-K"
+    assert record.before == before
+    assert record.after == after
+
+
+def test_load_dashboard_recommendations(monkeypatch):
+    sample_history = [
+        EvaluationResult(
+            timestamp="2024-01-01T00:00:00",
+            query="q",
+            answer="a",
+            contexts=[],
+            score=0.5,
+            rationale="",
+            faithfulness=0.8,
+            relevancy=0.5,
+            precision=0.9,
+        )
+    ]
+
+    def fake_load_history(start, end):
+        return sample_history
+
+    monkeypatch.setattr(EVALUATOR, "load_history", fake_load_history)
+    summary, fig, df, alerts, recs, *_ = _load_dashboard(None, None)
+    assert "Expand top-K" in recs

--- a/tests/test_ui/test_evaluate.py
+++ b/tests/test_ui/test_evaluate.py
@@ -52,7 +52,7 @@ def test_load_dashboard_filters_and_exports(monkeypatch):
         return records
 
     monkeypatch.setattr(EVALUATOR, "load_history", fake_load)
-    summary, fig, df, alerts, csv_update, json_update = _load_dashboard(
+    summary, fig, df, alerts, recs, csv_update, json_update = _load_dashboard(
         "2020-01-01", None
     )
     assert isinstance(captured["start"], datetime)
@@ -61,6 +61,7 @@ def test_load_dashboard_filters_and_exports(monkeypatch):
     assert csv_update["value"].startswith(b"timestamp")
     assert json_update["value"].startswith(b"[")
     assert "q1" in alerts
+    assert recs == "No recommendations"
 
 
 def test_alerts_use_thresholds(monkeypatch):
@@ -102,9 +103,9 @@ def test_alerts_use_thresholds(monkeypatch):
 
     monkeypatch.setattr(config_manager, "get", fake_get)
 
-    _, _, _, alerts, _, _ = _load_dashboard(None, None)
+    _, _, _, alerts, _, _, _ = _load_dashboard(None, None)
     assert "q1" in alerts and "q2" in alerts
 
     thresholds.update({"faithfulness": 0.5, "relevancy": 0.5, "precision": 0.5})
-    _, _, _, alerts, _, _ = _load_dashboard(None, None)
+    _, _, _, alerts, _, _, _ = _load_dashboard(None, None)
     assert alerts == "No alerts"


### PR DESCRIPTION
## Description:
- add recommendation generator with logging support
- surface recommendations on evaluation dashboard
- cover recommendation logic with unit tests

## Testing Done:
- `black src/ tests/ app.py`
- `flake8 src/ tests/ app.py` *(fails: E501 line too long in existing files)*
- `mypy src/ app.py`
- `python -m pytest tests/ -v`

## Performance Impact:
- no impact

## Configuration Changes:
- none

## Evaluation Results:
- not applicable


------
https://chatgpt.com/codex/tasks/task_e_68bcd5cd1c548322a70bc0c75fa92e64