### PR TITLE
improve(ui): expand evaluation metrics

### DIFF
--- a/tests/test_evaluation/test_recommendations.py
+++ b/tests/test_evaluation/test_recommendations.py
@@ -58,5 +58,5 @@ def test_load_dashboard_recommendations(monkeypatch):
         return sample_history
 
     monkeypatch.setattr(EVALUATOR, "load_history", fake_load_history)
-    summary, fig, df, alerts, recs, *_ = _load_dashboard(None, None)
+    summary, fig, df, corr, alerts, recs, *_ = _load_dashboard(None, None)
     assert "Expand top-K" in recs


### PR DESCRIPTION
## Description:
- handle three evaluation metrics with trend lines and correlations
- expose metric correlations, alerts, and recommendations in dashboard
- verify new UI components and recommendation generation

## Testing Done:
- `flake8 src/ui/evaluate.py tests/test_ui/test_evaluate.py tests/test_evaluation/test_recommendations.py`
- `mypy src/ui/evaluate.py tests/test_ui/test_evaluate.py`
- `python -m pytest tests/ -v`

## Performance Impact:
- negligible

## Configuration Changes:
- none

## Evaluation Results:
- not applicable


------
https://chatgpt.com/codex/tasks/task_e_68bcda221ad08322857ce907c5c5e960