### PR TITLE
feat(monitoring): track per-mode latency p95

### DIFF
--- a/src/monitoring/performance.py
+++ b/src/monitoring/performance.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import logging
 import time
 import tracemalloc
+from collections import deque
 from typing import Any, Callable, Dict, List
+
+import numpy as np
 
 
 class MemoryMonitor:
@@ -48,6 +53,8 @@ class PerformanceTracker:
         latency_threshold_ms: float | None = None,
         memory_threshold_mb: float | None = None,
         logger: logging.Logger | None = None,
+        retrieval_mode: str | None = None,
+        dashboard: MetricsDashboard | None = None,
     ) -> None:
         self.latency_threshold_ms = latency_threshold_ms
         self.memory_threshold_mb = memory_threshold_mb
@@ -56,6 +63,8 @@ class PerformanceTracker:
         self.memory_mb = 0.0
         self._start = 0.0
         self._mem: MemoryMonitor | None = None
+        self.retrieval_mode = retrieval_mode
+        self.dashboard = dashboard
 
     def __enter__(self) -> "PerformanceTracker":
         self._start = time.perf_counter()
@@ -81,9 +90,22 @@ class PerformanceTracker:
                 "memory_mb": self.memory_mb,
             },
         )
+        if self.dashboard and self.retrieval_mode:
+            p95 = self.dashboard.record_latency(self.retrieval_mode, self.latency_ms)
+            if p95 > 2000:
+                self.logger.warning(
+                    "p95 latency threshold exceeded",
+                    extra={"mode": self.retrieval_mode, "p95_ms": p95},
+                )
 
-    def metrics(self) -> Dict[str, float]:
-        return {"latency": self.latency_ms, "memory": self.memory_mb}
+    def metrics(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "latency": self.latency_ms,
+            "memory": self.memory_mb,
+        }
+        if self.retrieval_mode:
+            data["mode"] = self.retrieval_mode
+        return data
 
 
 class ModelCache:
@@ -117,14 +139,32 @@ class ModelCache:
 class MetricsDashboard:
     """In-memory store for recent metrics."""
 
-    def __init__(self) -> None:
-        self._records: List[Dict[str, float]] = []
+    def __init__(self, window_size: int = 100) -> None:
+        self._records: List[Dict[str, Any]] = []
+        self.window_size = window_size
+        self._latencies: Dict[str, deque[float]] = {}
+        self._p95: Dict[str, float] = {}
 
-    def log(self, data: Dict[str, float]) -> None:
+    def log(self, data: Dict[str, Any]) -> None:
         self._records.append(data)
 
-    def latest(self) -> Dict[str, float]:
+    def record_latency(self, mode: str, latency_ms: float) -> float:
+        window = self._latencies.setdefault(mode, deque(maxlen=self.window_size))
+        window.append(latency_ms)
+        p95 = float(np.percentile(list(window), 95))
+        self._p95[mode] = p95
+        return p95
+
+    def p95_latency(self, mode: str) -> float:
+        return self._p95.get(mode, 0.0)
+
+    def p95_metrics(self) -> Dict[str, float]:
+        return dict(self._p95)
+
+    def latest(self) -> Dict[str, Any]:
         return self._records[-1] if self._records else {}
 
     def reset(self) -> None:
         self._records.clear()
+        self._latencies.clear()
+        self._p95.clear()

--- a/src/query_service.py
+++ b/src/query_service.py
@@ -23,7 +23,9 @@ class QueryService:
         self, query: str, mode: Optional[str] = None, top_k: int = 5
     ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
         retrieval_mode = mode or self.default_mode
-        with PerformanceTracker() as perf:
+        with PerformanceTracker(
+            retrieval_mode=retrieval_mode, dashboard=self.dashboard
+        ) as perf:
             results, meta = self.retriever.query(query, mode=retrieval_mode, top_k=top_k)
         metrics = perf.metrics()
         meta.update(metrics)

--- a/tests/test_monitoring/test_performance.py
+++ b/tests/test_monitoring/test_performance.py
@@ -2,7 +2,13 @@ import logging
 import time
 import tracemalloc
 
-from src.monitoring.performance import ModelCache, PerformanceTracker
+import pytest
+
+from src.monitoring.performance import (
+    MetricsDashboard,
+    ModelCache,
+    PerformanceTracker,
+)
 
 
 def test_performance_tracker_alert(monkeypatch, caplog):
@@ -32,3 +38,32 @@ def test_model_cache_cleanup():
     assert cache.keys() == ["a"]
     cache.get("b", lambda: object())
     assert cache.keys() == ["b"]
+
+
+def _run_latency(monkeypatch, dashboard, latency_ms: float, mode: str = "dense") -> None:
+    times = [0, latency_ms / 1000]
+    monkeypatch.setattr(time, "perf_counter", lambda: times.pop(0))
+    with PerformanceTracker(dashboard=dashboard, retrieval_mode=mode):
+        pass
+
+
+def test_p95_latency_calculation(monkeypatch):
+    dashboard = MetricsDashboard(window_size=5)
+    monkeypatch.setattr(tracemalloc, "start", lambda: None)
+    monkeypatch.setattr(tracemalloc, "stop", lambda: None)
+    monkeypatch.setattr(tracemalloc, "get_traced_memory", lambda: (0, 0))
+    for latency in [100, 200, 300, 400, 500]:
+        _run_latency(monkeypatch, dashboard, latency)
+    assert dashboard.p95_latency("dense") == pytest.approx(480.0)
+
+
+def test_p95_latency_warning(monkeypatch, caplog):
+    dashboard = MetricsDashboard(window_size=5)
+    monkeypatch.setattr(tracemalloc, "start", lambda: None)
+    monkeypatch.setattr(tracemalloc, "stop", lambda: None)
+    monkeypatch.setattr(tracemalloc, "get_traced_memory", lambda: (0, 0))
+    caplog.set_level(logging.WARNING, logger="src.monitoring.performance")
+    for latency in [3000, 3000, 3000, 3000, 100]:
+        _run_latency(monkeypatch, dashboard, latency)
+    assert dashboard.p95_latency("dense") > 2000
+    assert "p95 latency threshold exceeded" in caplog.text


### PR DESCRIPTION
## Description:
- track per-query latencies by retrieval mode with percentile warnings
- expose per-mode p95 metrics via `MetricsDashboard`
- add tests validating p95 computation and alerts

## Testing Done:
- `black src/ tests/ app.py`
- `flake8 src/ tests/ app.py`
- `mypy src/monitoring/performance.py src/query_service.py`
- `python -m pytest tests/ -v`

## Performance Impact:
- minor overhead for percentile tracking over rolling windows

## Configuration Changes:
- `MetricsDashboard` accepts configurable `window_size`

## Evaluation Results:
- N/A


------
https://chatgpt.com/codex/tasks/task_e_68bce62cebf8832286cce6be99fd303e