### PR TITLE
feat(monitoring): add latency auto tuner

### DIFF
--- a/src/monitoring/auto_tuner.py
+++ b/src/monitoring/auto_tuner.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Automatic tuning of retrieval parameters based on latency."""
+
+from dataclasses import dataclass
+from typing import Dict, Any
+
+from src.monitoring.performance import MetricsDashboard
+from src.config.runtime_config import ConfigManager, config_manager
+
+
+@dataclass
+class AutoTuner:
+    """Reduce retrieval costs when latency exceeds threshold."""
+
+    dashboard: MetricsDashboard
+    threshold_ms: float = 2000
+    config: ConfigManager | None = config_manager
+
+    def tune(self, mode: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Adjust parameters if recent latency p95 is above threshold."""
+        tuned = dict(params)
+        p95 = self.dashboard.p95_latency(mode)
+        if p95 <= self.threshold_ms:
+            return tuned
+
+        locks = set()
+        if self.config:
+            locks = set(self.config.get("tuner_locks", []))
+
+        if tuned.get("enable_rerank") and "enable_rerank" not in locks:
+            tuned["enable_rerank"] = False
+        elif "top_k" not in locks and tuned.get("top_k", 1) > 1:
+            tuned["top_k"] = max(1, tuned["top_k"] - 1)
+        elif "rrf_k" not in locks and tuned.get("k", 10) > 10:
+            tuned["k"] = max(10, tuned["k"] - 10)
+
+        return tuned

--- a/src/query_service.py
+++ b/src/query_service.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Dict, List, Optional, Tuple
 
+from src.config.runtime_config import ConfigManager, config_manager
+from src.monitoring.auto_tuner import AutoTuner
 from src.monitoring.performance import MetricsDashboard, PerformanceTracker
 from src.retrieval.hybrid import HybridRetriever
 
@@ -14,19 +16,36 @@ class QueryService:
         retriever: HybridRetriever,
         default_mode: str = "hybrid",
         dashboard: MetricsDashboard | None = None,
+        auto_tuner: AutoTuner | None = None,
+        config: ConfigManager | None = None,
     ) -> None:
         self.retriever = retriever
         self.default_mode = default_mode
         self.dashboard = dashboard or MetricsDashboard()
+        self.auto_tuner = auto_tuner
+        self.config = config or config_manager
 
     def query(
-        self, query: str, mode: Optional[str] = None, top_k: int = 5
+        self, query: str, mode: Optional[str] = None, top_k: int | None = None
     ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
         retrieval_mode = mode or self.default_mode
+        params = {
+            "top_k": top_k if top_k is not None else self.config.get("top_k", 5),
+            "k": self.config.get("rrf_k", 60),
+            "enable_rerank": self.config.get("enable_rerank", False),
+        }
+        if self.auto_tuner:
+            params = self.auto_tuner.tune(retrieval_mode, params)
         with PerformanceTracker(
             retrieval_mode=retrieval_mode, dashboard=self.dashboard
         ) as perf:
-            results, meta = self.retriever.query(query, mode=retrieval_mode, top_k=top_k)
+            results, meta = self.retriever.query(
+                query,
+                mode=retrieval_mode,
+                top_k=params["top_k"],
+                k=params["k"],
+                enable_rerank=params["enable_rerank"],
+            )
         metrics = perf.metrics()
         meta.update(metrics)
         self.dashboard.log(metrics)

--- a/tests/test_monitoring/test_auto_tuner.py
+++ b/tests/test_monitoring/test_auto_tuner.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from src.config.runtime_config import ConfigManager
+from src.monitoring.auto_tuner import AutoTuner
+from src.monitoring.performance import MetricsDashboard
+
+
+def test_auto_tuner_reduces_top_k() -> None:
+    dashboard = MetricsDashboard()
+    dashboard.record_latency("hybrid", 2500)
+    tuner = AutoTuner(dashboard)
+    params = {"top_k": 5, "k": 60, "enable_rerank": False}
+    tuned = tuner.tune("hybrid", params)
+    assert tuned["top_k"] == 4
+
+
+def test_auto_tuner_respects_locks() -> None:
+    dashboard = MetricsDashboard()
+    dashboard.record_latency("hybrid", 2500)
+    cm = ConfigManager(base_config={"top_k": 5, "rrf_k": 60})
+    cm.set_runtime_overrides({"tuner_locks": ["top_k"], "top_k": 7})
+    tuner = AutoTuner(dashboard, config=cm)
+    params = {"top_k": 7, "k": 60, "enable_rerank": False}
+    tuned = tuner.tune("hybrid", params)
+    assert tuned["top_k"] == 7

--- a/tests/test_query_service.py
+++ b/tests/test_query_service.py
@@ -5,7 +5,7 @@ class StubHybrid:
     def __init__(self) -> None:
         self.last_mode = None
 
-    def query(self, query, mode=None, top_k=5):
+    def query(self, query, mode=None, top_k=5, **kwargs):
         self.last_mode = mode
         return [], {}
 


### PR DESCRIPTION
## Description:
- add AutoTuner to trim retrieval parameters when p95 latency exceeds threshold
- integrate auto tuner and config overrides with QueryService
- cover tuning and lock behaviour with new unit tests

## Testing Done:
- `python -m pytest tests/ -v`

## Performance Impact:
- reduces query latency when p95 exceeds 2000ms by trimming parameters

## Configuration Changes:
- supports `tuner_locks` runtime config key to prevent auto-tuning of specific parameters

## Evaluation Results:
- N/A


------
https://chatgpt.com/codex/tasks/task_e_68bd794e73ac83228e74a6b6de822c1d