### PR TITLE
feat(ui): add performance metrics and overrides

### DIFF
--- a/tests/test_ui/test_settings_performance.py
+++ b/tests/test_ui/test_settings_performance.py
@@ -1,0 +1,30 @@
+import gradio as gr
+from gradio.components import JSON
+
+from src.ui.settings import (
+    settings_page,
+    update_field,
+    update_policy_field,
+)
+from src.ui.chat import QUERY_SERVICE
+from src.config.runtime_config import config_manager
+
+
+def test_performance_tab_displays_metrics():
+    dashboard = QUERY_SERVICE.dashboard
+    dashboard.record_latency("hybrid", 100)
+    dashboard.record_latency("hybrid", 200)
+    demo = settings_page()
+    json_components = [c for c in demo.blocks.values() if isinstance(c, JSON)]
+    metrics = json_components[0].value
+    assert "hybrid" in metrics
+
+
+def test_manual_overrides_update_config_manager():
+    original = config_manager.as_dict()
+    settings = original
+    settings, _ = update_policy_field("target_p95_ms", 2500, settings)
+    assert config_manager.get("performance_policy")["target_p95_ms"] == 2500
+    settings, _ = update_field("enable_rerank", True, settings)
+    assert config_manager.get("enable_rerank") is True
+    config_manager.set_runtime_overrides({})


### PR DESCRIPTION
## Description:
- replace performance tab with p95 metrics, policy controls, and latency trends
- add UI tests for metrics display and override wiring

## Testing Done:
- `python -m pytest tests/test_ui/test_settings_performance.py -v`
- `python -m pytest tests/ -v` *(fails: fixture 'benchmark' not found in test_reranker_benchmark)*

## Performance Impact:
- none

## Configuration Changes:
- optional runtime overrides for `performance_policy` and `enable_rerank`

## Evaluation Results:
- not applicable

------
https://chatgpt.com/codex/tasks/task_e_68bd834535a8832284cf1b32f937d35a