### PR TITLE
test(monitoring): verify performance tracker dashboard integration

### DIFF
--- a/tests/test_monitoring/test_tracker_dashboard.py
+++ b/tests/test_monitoring/test_tracker_dashboard.py
@@ -1,0 +1,39 @@
+import logging
+import time
+import tracemalloc
+
+import pytest
+
+from src.monitoring.performance import MetricsDashboard, PerformanceTracker
+
+
+def test_performance_tracker_with_dashboard(monkeypatch, caplog):
+    dashboard = MetricsDashboard()
+    caplog.set_level(logging.WARNING, logger="src.monitoring.performance")
+    times = [0, 0.2]
+    monkeypatch.setattr(time, "perf_counter", lambda: times.pop(0))
+    mem_reads = [
+        (0, 0),
+        (10 * 1024 * 1024, 10 * 1024 * 1024),
+    ]
+    monkeypatch.setattr(tracemalloc, "start", lambda: None)
+    monkeypatch.setattr(tracemalloc, "stop", lambda: None)
+    monkeypatch.setattr(
+        tracemalloc,
+        "get_traced_memory",
+        lambda: mem_reads.pop(0),
+    )
+    with PerformanceTracker(
+        latency_threshold_ms=100,
+        memory_threshold_mb=1,
+        retrieval_mode="dense",
+        dashboard=dashboard,
+    ) as tracker:
+        pass
+    dashboard.log(tracker.metrics())
+    latest = dashboard.latest()
+    assert latest["latency"] == pytest.approx(200.0)
+    assert latest["memory"] == pytest.approx(10.0, rel=1e-3)
+    assert dashboard.p95_latency("dense") == pytest.approx(tracker.latency_ms)
+    assert "performance" in caplog.text
+    assert "memory threshold exceeded" in caplog.text


### PR DESCRIPTION
## Description:
- add regression test ensuring `PerformanceTracker` logs latency/memory to a shared `MetricsDashboard`
- validate p95 latency updates and threshold warnings

## Testing Done:
- `flake8 tests/test_monitoring/test_tracker_dashboard.py`
- `mypy src/ app.py`
- `python -m pytest tests/test_monitoring/test_tracker_dashboard.py -v`
- `python -m pytest tests/ -v` *(fails: fixture 'benchmark' not found in test_reranker_benchmark)*

## Performance Impact:
- none

## Configuration Changes:
- none

## Evaluation Results:
- not applicable

------
https://chatgpt.com/codex/tasks/task_e_68bd912f49648322bd7c9fe32b19e07d