### PR TITLE
improve(retrieval): defer model load and add async wrappers

### DIFF
--- a/src/retrieval/dense.py
+++ b/src/retrieval/dense.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Any, Dict, List, Tuple
 from uuid import uuid4
@@ -24,49 +25,71 @@ class DenseRetriever:
         self.index_name = index_name
         self.device = device
         self.precision = precision
-        st_device = "xpu" if device == "gpu_xpu" else "cpu"
-        self.model = SentenceTransformer("all-MiniLM-L6-v2", device=st_device)
-        self.ov_model = None
-        if device == "gpu_openvino":
-            try:
-                from openvino.runtime import Core  # type: ignore
+        self._model: SentenceTransformer | None = None
+        self._ov_model: Any | None = None
+        self._load_lock = asyncio.Lock()
 
-                core = Core()
-                self.ov_model = core.compile_model(
-                    self.model, "GPU", {"INFERENCE_PRECISION_HINT": precision}
-                )
-            except Exception as exc:  # pragma: no cover
-                self._logger.warning("OpenVINO load failed: %s", exc)
-        dimension = self.model.get_sentence_embedding_dimension()
-        if dimension != EMBEDDING_DIMENSION:
-            self._logger.warning(
-                "Loaded model has dimension %s, expected %s",
-                dimension,
-                EMBEDDING_DIMENSION,
-            )
+    async def _ensure_model(self) -> None:
+        if self._model is None:
+            async with self._load_lock:
+                if self._model is None:
+                    st_device = "xpu" if self.device == "gpu_xpu" else "cpu"
+                    try:
+                        model = await asyncio.to_thread(
+                            SentenceTransformer,
+                            "all-MiniLM-L6-v2",
+                            device=st_device,
+                        )
+                    except Exception as exc:  # pragma: no cover
+                        raise RuntimeError(
+                            f"Failed to load SentenceTransformer: {exc}"
+                        ) from exc
+                    dimension = model.get_sentence_embedding_dimension()
+                    if dimension != EMBEDDING_DIMENSION:
+                        raise ValueError(
+                            "Loaded model has dimension %s, expected %s"
+                            % (dimension, EMBEDDING_DIMENSION)
+                        )
+                    self._model = model
+                    if self.device == "gpu_openvino":
+                        try:
+                            from openvino.runtime import Core  # type: ignore
 
-    def _embed_documents(
+                            core = Core()
+                            self._ov_model = core.compile_model(
+                                self._model,
+                                "GPU",
+                                {"INFERENCE_PRECISION_HINT": self.precision},
+                            )
+                        except Exception as exc:  # pragma: no cover
+                            raise RuntimeError(f"OpenVINO load failed: {exc}") from exc
+
+    async def _embed_documents(
         self, documents: List[str], batch_size: int = 32
     ) -> List[List[float]]:
-        if self.device == "gpu_openvino" and self.ov_model is not None:
-            encode = getattr(self.ov_model, "encode", None)
+        await self._ensure_model()
+        assert self._model is not None
+        if self.device == "gpu_openvino" and self._ov_model is not None:
+            encode = getattr(self._ov_model, "encode", None)
             if callable(encode):
-                embeddings = encode(documents)
+                embeddings = await asyncio.to_thread(encode, documents)
             else:
-                embeddings = self.model.encode(
+                embeddings = await asyncio.to_thread(
+                    self._model.encode,
                     documents,
                     batch_size=batch_size,
                     show_progress_bar=False,
                 )
         else:
-            embeddings = self.model.encode(
+            embeddings = await asyncio.to_thread(
+                self._model.encode,
                 documents,
                 batch_size=batch_size,
                 show_progress_bar=False,
             )
         return embeddings.tolist()
 
-    def index_corpus(
+    async def index_corpus(
         self,
         documents: List[str],
         metadatas: List[Dict[str, Any]],
@@ -77,7 +100,7 @@ class DenseRetriever:
             valid, _ = self.validate_index()
             if not valid:
                 raise ValueError("Invalid Pinecone index configuration")
-            embeddings = self._embed_documents(
+            embeddings = await self._embed_documents(
                 documents,
                 batch_size=batch_size,
             )
@@ -97,21 +120,30 @@ class DenseRetriever:
             self._logger.error("Failed to index corpus: %s", exc)
             return [], {"status": "error", "error": str(exc)}
 
-    def embed_query(self, query: str) -> Tuple[List[float], Dict[str, Any]]:
+    async def embed_query(self, query: str) -> Tuple[List[float], Dict[str, Any]]:
         """Embed a query string."""
         try:
-            embedding = self.model.encode(query).tolist()
-            return embedding, {"embedding_dimension": EMBEDDING_DIMENSION}
+            await self._ensure_model()
+            assert self._model is not None
+            if self.device == "gpu_openvino" and self._ov_model is not None:
+                encode = getattr(self._ov_model, "encode", None)
+                if callable(encode):
+                    embedding = await asyncio.to_thread(encode, query)
+                else:
+                    embedding = await asyncio.to_thread(self._model.encode, query)
+            else:
+                embedding = await asyncio.to_thread(self._model.encode, query)
+            return embedding.tolist(), {"embedding_dimension": EMBEDDING_DIMENSION}
         except Exception as exc:  # pragma: no cover
             self._logger.error("Failed to embed query: %s", exc)
             return [], {"status": "error", "error": str(exc)}
 
-    def query(
+    async def query(
         self, query: str, top_k: int = 5
     ) -> Tuple[List[Tuple[str, float]], Dict[str, Any]]:
         """Query the Pinecone index with a text string."""
         try:
-            embedding, _ = self.embed_query(query)
+            embedding, _ = await self.embed_query(query)
             response = self.pinecone_client.query(self.index_name, embedding, top_k=top_k)
             matches = getattr(response, "matches", [])
             results = [(m["id"], m["score"]) for m in matches]
@@ -132,9 +164,10 @@ class DenseRetriever:
             return False, {"status": "error", "error": str(exc)}
 
     # Index management helpers
-    def delete_document(self, doc_id: str) -> Dict[str, Any]:
+    async def delete_document(self, doc_id: str) -> Dict[str, Any]:
         """Delete a document from the Pinecone index."""
         try:
+            await self._ensure_model()
             delete = getattr(self.pinecone_client, "delete_embeddings", None)
             if delete:
                 delete(self.index_name, [doc_id])
@@ -143,14 +176,44 @@ class DenseRetriever:
             self._logger.error("Failed to delete %s: %s", doc_id, exc)
             return {"status": "error", "error": str(exc)}
 
-    def update_document(
+    async def update_document(
         self, doc_id: str, content: str, metadata: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Update a document by re-indexing its content."""
         try:
-            self.delete_document(doc_id)
-            ids, _ = self.index_corpus([content], [metadata])
+            await self.delete_document(doc_id)
+            ids, _ = await self.index_corpus([content], [metadata])
             return {"status": "success", "id": ids[0] if ids else doc_id}
         except Exception as exc:  # pragma: no cover
             self._logger.error("Failed to update %s: %s", doc_id, exc)
             return {"status": "error", "error": str(exc)}
+
+    # Synchronous wrappers for backward compatibility
+    def embed_query_sync(self, query: str) -> Tuple[List[float], Dict[str, Any]]:
+        return asyncio.run(self.embed_query(query))
+
+    def _embed_documents_sync(
+        self, documents: List[str], batch_size: int = 32
+    ) -> List[List[float]]:
+        return asyncio.run(self._embed_documents(documents, batch_size))
+
+    def index_corpus_sync(
+        self,
+        documents: List[str],
+        metadatas: List[Dict[str, Any]],
+        batch_size: int = 32,
+    ) -> Tuple[List[str], Dict[str, Any]]:
+        return asyncio.run(self.index_corpus(documents, metadatas, batch_size=batch_size))
+
+    def query_sync(
+        self, query: str, top_k: int = 5
+    ) -> Tuple[List[Tuple[str, float]], Dict[str, Any]]:
+        return asyncio.run(self.query(query, top_k=top_k))
+
+    def delete_document_sync(self, doc_id: str) -> Dict[str, Any]:
+        return asyncio.run(self.delete_document(doc_id))
+
+    def update_document_sync(
+        self, doc_id: str, content: str, metadata: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        return asyncio.run(self.update_document(doc_id, content, metadata))


### PR DESCRIPTION
## Description:
- defer dense SentenceTransformer model loading until first use
- introduce async embeddings and index management with sync wrappers for backwards compatibility
- update dense retriever tests for async interface

## Testing Done:
- `flake8 src/ tests/ app.py` *(fails: line too long across repository)*
- `mypy src/retrieval/dense.py tests/test_retrieval/test_dense.py app.py` *(hangs and was interrupted)*
- `python -m pytest tests/ -v` *(fails: fixture 'benchmark' not found in test_reranker_benchmark)*

## Performance Impact:
- model initialization deferred to first request to reduce startup latency

## Configuration Changes:
- none

## Evaluation Results:
- not applicable


------
https://chatgpt.com/codex/tasks/task_e_68bd9ace6a6c83229ebeee2688884b57