### PR TITLE
docs: switch mypy references to pyright

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ CPU remains the default execution target, though optional OpenVINO/XPU accelerat
 - To run tests with coverage: `python -m pytest tests/ --cov=src --cov-report=html`
 - To format code: `black src/ tests/ app.py`
 - To run linting: `flake8 src/ tests/ app.py`
-- To run type checking: `mypy src/ app.py`
+- To run type checking: `pyright`
 - To validate configuration: `python -m src.config.validate`
 
 **Testing Specific Components:**

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ python -m pytest tests/ --cov=src --cov-report=html
 # Code formatting and linting
 black src/ tests/ app.py
 flake8 src/ tests/ app.py
-mypy src/ app.py
+pyright
 ```
 
 ### Testing


### PR DESCRIPTION
## Summary
- replace mypy references with pyright in docs
- update AGENTS instructions to use pyright for type checking

## Testing
- `pyright` *(failed: KeyboardInterrupt)*
- `python -m pytest tests/ -v` *(failed: fixture 'benchmark' not found in test_reranker_benchmark)*
- `python scripts/validate_rrf.py` *(missing: file not found)*
- `python scripts/benchmark_retrieval.py` *(missing: file not found)*
- `python scripts/validate_pinecone.py` *(missing: file not found)*
- `python scripts/test_ui_routing.py` *(missing: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9f8908b48322aa9706b58b97f939