### PR TITLE
improve(config): add pyright configuration

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,8 @@
+{
+  "typeCheckingMode": "strict",
+  "pythonVersion": "3.12",
+  "venvPath": ".",
+  "venv": ".venv",
+  "include": ["src", "app.py", "tests"],
+  "exclude": [".venv", ".git", "node_modules", "**/__pycache__"]
+}


### PR DESCRIPTION
## Description:
- add `pyrightconfig.json` to enable strict type checking with Python 3.12

## Testing Done:
- `pyright --verifytypes .`
- `python -m pytest tests/ -v` *(interrupted: KeyboardInterrupt after collection)*

## Performance Impact:
- none expected

## Configuration Changes:
- new `pyrightconfig.json` sets strict mode, Python 3.12, and local `.venv`

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bda5490af883229ae1f0efe55ff529