### PR TITLE
docs(contributing): add Pyright guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+Thanks for taking the time to contribute to Personal RAG Copilot!
+
+## Code Quality
+
+- Format code with `black src/ tests/ app.py`.
+- Lint with `flake8 src/ tests/ app.py`.
+- This project uses **Pyright** instead of mypy for type checking:
+  - Run a full type check with `pyright`.
+  - For rapid feedback, use watch mode: `pyright --watch`.
+- Pyright is chosen for its speed and consistency with editor integrations.
+
+## Testing
+
+- Ensure all tests pass with `python -m pytest tests/ -v` before submitting a PR.
+


### PR DESCRIPTION
## Description:
- add CONTRIBUTING guide highlighting formatting, linting, and type checking
- document Pyright usage, including watch mode and rationale versus mypy

## Testing Done:
- `python -m pytest tests/ -v`
- `pyright` *(fails: 938 errors)*

## Performance Impact:
- none

## Configuration Changes:
- none

## Evaluation Results:
- not applicable


------
https://chatgpt.com/codex/tasks/task_e_68bda779f2cc83228bf6787e08fd7cb7