### PR TITLE
docs(testing): add warnings report

### DIFF
--- a/warnings_report.md
+++ b/warnings_report.md
@@ -1,0 +1,149 @@
+# Test Warnings Report
+
+- Generated: 2025-09-07T15:51:01Z
+- Pytest exit status: 0
+- Total warnings: 18
+
+## Warning 1
+- **File:** `/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/websockets/legacy/__init__.py`
+- **Line:** 6
+- **When:** `collect`
+- **NodeID:** ``
+- **Category:** `DeprecationWarning`
+- **Message:** websockets.legacy is deprecated; see https://websockets.readthedocs.io/en/stable/howto/upgrade.html for upgrade instructions
+
+## Warning 2
+- **File:** `/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/gradio/chat_interface.py`
+- **Line:** 345
+- **When:** `collect`
+- **NodeID:** ``
+- **Category:** `UserWarning`
+- **Message:** The 'tuples' format for chatbot messages is deprecated and will be removed in a future version of Gradio. Please set type='messages' instead, which uses openai-style 'role' and 'content' keys.
+
+## Warning 3
+- **File:** `/workspace/personal-rag-copilot/src/config/backup.py`
+- **Line:** 16
+- **When:** `runtest`
+- **NodeID:** `tests/test_config/test_backup.py::test_backup_and_restore`
+- **Category:** `DeprecationWarning`
+- **Message:** datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+
+## Warning 4
+- **File:** `/workspace/personal-rag-copilot/src/evaluation/ragas_integration.py`
+- **Line:** 61
+- **When:** `runtest`
+- **NodeID:** `tests/test_evaluation/test_ragas_integration.py::test_evaluate_records_history`
+- **Category:** `DeprecationWarning`
+- **Message:** datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+
+## Warning 5
+- **File:** `/workspace/personal-rag-copilot/src/services/index_management.py`
+- **Line:** 30
+- **When:** `runtest`
+- **NodeID:** `tests/test_services/test_document_service.py::test_update_delete_and_audit`
+- **Category:** `DeprecationWarning`
+- **Message:** datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+
+## Warning 6
+- **File:** `/workspace/personal-rag-copilot/src/services/index_management.py`
+- **Line:** 42
+- **When:** `runtest`
+- **NodeID:** `tests/test_services/test_document_service.py::test_update_delete_and_audit`
+- **Category:** `DeprecationWarning`
+- **Message:** datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+
+## Warning 7
+- **File:** `/workspace/personal-rag-copilot/src/services/index_management.py`
+- **Line:** 30
+- **When:** `runtest`
+- **NodeID:** `tests/test_services/test_document_service.py::test_bulk_operations_audit`
+- **Category:** `DeprecationWarning`
+- **Message:** datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+
+## Warning 8
+- **File:** `/workspace/personal-rag-copilot/src/services/index_management.py`
+- **Line:** 42
+- **When:** `runtest`
+- **NodeID:** `tests/test_services/test_document_service.py::test_bulk_operations_audit`
+- **Category:** `DeprecationWarning`
+- **Message:** datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+
+## Warning 9
+- **File:** `/workspace/personal-rag-copilot/src/services/index_management.py`
+- **Line:** 30
+- **When:** `runtest`
+- **NodeID:** `tests/test_services/test_index_management.py::test_update_and_delete_record_audit`
+- **Category:** `DeprecationWarning`
+- **Message:** datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+
+## Warning 10
+- **File:** `/workspace/personal-rag-copilot/src/services/index_management.py`
+- **Line:** 42
+- **When:** `runtest`
+- **NodeID:** `tests/test_services/test_index_management.py::test_update_and_delete_record_audit`
+- **Category:** `DeprecationWarning`
+- **Message:** datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+
+## Warning 11
+- **File:** `/workspace/personal-rag-copilot/src/services/index_management.py`
+- **Line:** 30
+- **When:** `runtest`
+- **NodeID:** `tests/test_services/test_index_management.py::test_bulk_operations_and_error`
+- **Category:** `DeprecationWarning`
+- **Message:** datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+
+## Warning 12
+- **File:** `/workspace/personal-rag-copilot/src/services/index_management.py`
+- **Line:** 42
+- **When:** `runtest`
+- **NodeID:** `tests/test_services/test_index_management.py::test_bulk_operations_and_error`
+- **Category:** `DeprecationWarning`
+- **Message:** datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+
+## Warning 13
+- **File:** `/workspace/personal-rag-copilot/src/services/index_management.py`
+- **Line:** 60
+- **When:** `runtest`
+- **NodeID:** `tests/test_services/test_index_management.py::test_log_retrieval_records_and_exports`
+- **Category:** `DeprecationWarning`
+- **Message:** datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+
+## Warning 14
+- **File:** `/workspace/personal-rag-copilot/src/ui/chat.py`
+- **Line:** 46
+- **When:** `runtest`
+- **NodeID:** `tests/test_ui/test_chat.py::test_append_history_writes`
+- **Category:** `DeprecationWarning`
+- **Message:** datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+
+## Warning 15
+- **File:** `/workspace/personal-rag-copilot/src/ui/chat.py`
+- **Line:** 46
+- **When:** `runtest`
+- **NodeID:** `tests/test_ui/test_chat.py::test_generate_response_streams`
+- **Category:** `DeprecationWarning`
+- **Message:** datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+
+## Warning 16
+- **File:** `/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/gradio/chat_interface.py`
+- **Line:** 345
+- **When:** `runtest`
+- **NodeID:** `tests/test_ui/test_chat.py::test_chat_page_has_chat_interface`
+- **Category:** `UserWarning`
+- **Message:** The 'tuples' format for chatbot messages is deprecated and will be removed in a future version of Gradio. Please set type='messages' instead, which uses openai-style 'role' and 'content' keys.
+
+## Warning 17
+- **File:** `/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py`
+- **Line:** 27
+- **When:** `runtest`
+- **NodeID:** `tests/test_ui/test_evaluate.py::test_load_dashboard_filters_and_exports`
+- **Category:** `DeprecationWarning`
+- **Message:** datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
+
+## Warning 18
+- **File:** `/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py`
+- **Line:** 76
+- **When:** `runtest`
+- **NodeID:** `tests/test_ui/test_evaluate.py::test_alerts_use_thresholds`
+- **Category:** `DeprecationWarning`
+- **Message:** datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).


### PR DESCRIPTION
## Description:
Adds the latest `warnings_report.md` generated from running the full pytest suite.

## Testing Done:
- `python -m pytest tests/ -v`
- `flake8 src/ tests/ app.py`
- `pyright` *(fails: venv .venv subdirectory not found)*
- attempted to locate validation scripts (none found)

## Performance Impact:
- None

## Configuration Changes:
- None

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bda98a1f388322be55c7036bcd9cab