### PR TITLE
docs(project): document timezone-aware timestamps and messages ChatInterface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,10 @@ CPU remains the default execution target, though optional OpenVINO/XPU accelerat
 - Use `UPPER_CASE` for constants (e.g., `DEFAULT_RRF_K`, `EMBEDDING_DIMENSION`)
 - Prefix private methods with underscore (e.g., `_compute_rrf_scores`)
 
+**Datetime & Chat Interface Conventions:**
+- All timestamps MUST be timezone-aware using `datetime.now(datetime.UTC)`; naive timestamps are prohibited.
+- Gradio chat components MUST use `ChatInterface` with `type="messages"` to maintain structured conversation history.
+
 **RRF Implementation Standards:**
 - RRF formula MUST use: `score(d) = Σᵢ 1/(k + rankᵢ(d))` with k=60 default
 - All RRF functions MUST accept configurable `k` parameter per query

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,11 @@ Thanks for taking the time to contribute to Personal RAG Copilot!
   - Run a full type check with `pyright`.
   - For rapid feedback, use watch mode: `pyright --watch`.
 - Pyright is chosen for its speed and consistency with editor integrations.
+- Use timezone-aware timestamps: always call `datetime.now(datetime.UTC)` instead of naive `datetime.now()`.
 
 ## Testing
 
 - Ensure all tests pass with `python -m pytest tests/ -v` before submitting a PR.
+- Verify timezone-sensitive logic by running tests under multiple zones, e.g.,
+  `TZ=UTC python -m pytest tests/ -v` and `TZ=US/Pacific python -m pytest tests/ -v`.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A hybrid retrieval-augmented generation platform combining dense vector search a
 - **Hybrid Search**: Dense vector retrieval (all-MiniLM-L6-v2) + lexical BM25 with Reciprocal Rank Fusion [[EVID: src/retrieval/hybrid.py:1-47 | HybridRetriever orchestrates both methods]]
 - **Advanced Ranking**: RRF fusion with k=60 default and optional BGE-Reranker-v2-m3 cross-encoder [[EVID: src/ranking/rrf_fusion.py:8-9 | DEFAULT_RRF_K = 60]]
 - **Quality Evaluation**: Ragas faithfulness assessment with automatic scoring [[EVID: src/evaluation/ragas_integration.py:33-65 | RagasEvaluator with faithfulness metric]]
-- **Multipage Interface**: Gradio 5 application with Chat, Ingest, Evaluate, and Settings pages [[EVID: app.py:8-12 | FastAPI with Gradio mounting]]
+- **Multipage Interface**: Gradio 5 application with Chat, Ingest, Evaluate, and Settings pages; the Chat page uses a messages-based `gr.ChatInterface` (`type="messages"`) for structured conversation state [[EVID: app.py:8-12 | FastAPI with Gradio mounting]]
 - **Document Processing**: Multi-format ingestion (PDF, DOCX, TXT, MD, HTML) with intelligent chunking [[EVID: src/services/document_service.py:22-75 | DocumentService with format support]]
 - **Transparency**: Retrieval audit trails with component scores and source attribution [[EVID: src/ranking/rrf_fusion.py:56-61 | metadata with fusion_method and component_scores]]
 - **Performance Policy Management**: Enforces latency targets and can auto-tune retrieval parameters [[EVID: src/config/default_settings.yaml:14-20 | performance_policy defaults]]
@@ -175,12 +175,18 @@ Response 200
 
 GET /api/v1/recommendations
 Response 200
+```
+
+```python
+from datetime import datetime, UTC
+
 {
   "items": [
-    {"timestamp": "2025-01-27T12:00:00Z", "recommendation": "Expand top-K"}
+    {"timestamp": datetime.now(UTC).isoformat(), "recommendation": "Expand top-K"}
   ]
 }
 ```
+All timestamps are generated using `datetime.now(datetime.UTC)` to ensure timezone awareness.
 
 ### API Usage
 

--- a/warnings_report.md
+++ b/warnings_report.md
@@ -1,6 +1,6 @@
 # Test Warnings Report
 
-- Generated: 2025-09-07T16:39:47Z
+- Generated: 2025-09-07T16:44:49Z
 - Pytest exit status: 0
 - Total warnings: 1
 


### PR DESCRIPTION
## Description:
- document timezone-aware timestamps (`datetime.now(datetime.UTC)`) in examples and guidelines
- note messages-based `gr.ChatInterface` usage

## Testing Done:
- `python -m pytest tests/ -v`

## Performance Impact:
- none

## Configuration Changes:
- none

## Evaluation Results:
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68bdb5de75cc8322bea5bcc45b4ad175