### PR TITLE
test(utils): annotate timezone test monkeypatch

### DIFF
--- a/tests/test_utils/test_timezone_handling.py
+++ b/tests/test_utils/test_timezone_handling.py
@@ -1,15 +1,21 @@
-import time
+from __future__ import annotations
+
 import datetime
+import time
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from src.config.backup import backup_config
-from src.services.index_management import IndexManagement
 from src.evaluation.ragas_integration import RagasEvaluator
+from src.services.index_management import IndexManagement
 
 
 class DummyDense:
-    def update_document(self, doc_id: str, content: str, metadata: dict | None = None):
+    def update_document(
+        self, doc_id: str, content: str, metadata: dict | None = None
+    ) -> dict:
         return {"status": "dense"}
 
     def delete_document(self, doc_id: str):
@@ -29,7 +35,10 @@ class DummyLexical:
     bm25 = object()
 
 
-def test_utc_now_across_modules(tmp_path: Path, monkeypatch):
+def test_utc_now_across_modules(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("TZ", "US/Pacific")
     if hasattr(time, "tzset"):
         time.tzset()
@@ -57,5 +66,6 @@ def test_utc_now_across_modules(tmp_path: Path, monkeypatch):
             "context_precision": [0.0],
         }
         res = evaluator.evaluate("q", "a", ["c"])
-    ts_eval = datetime.datetime.fromisoformat(res.timestamp.replace("Z", "+00:00"))
+    timestamp_str = res.timestamp.replace("Z", "+00:00")
+    ts_eval = datetime.datetime.fromisoformat(timestamp_str)
     assert ts_eval.tzinfo is datetime.UTC

--- a/warnings_report.md
+++ b/warnings_report.md
@@ -1,6 +1,6 @@
 # Test Warnings Report
 
-- Generated: 2025-09-07T16:44:49Z
+- Generated: 2025-09-07T16:57:43Z
 - Pytest exit status: 0
 - Total warnings: 1
 


### PR DESCRIPTION
## Description:
- add `from __future__ import annotations` and `import pytest`
- type `monkeypatch` fixture in `test_utc_now_across_modules`

## Testing Done:
- `python -m pytest tests/ -v`
- `flake8 src/ tests/ app.py` *(fails: many E501 line too long errors across repository)*
- `pyright` *(fails: numerous type errors across repository)*
- `python scripts/validate_rrf.py` *(fails: file not found)*
- `python scripts/benchmark_retrieval.py` *(fails: file not found)*
- `python scripts/validate_pinecone.py` *(fails: file not found)*
- `python scripts/test_ui_routing.py` *(fails: file not found)*

## Performance Impact:
- none

## Configuration Changes:
- none

## Evaluation Results:
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68bdb8e22c148322b115262b20566a34