### PR TITLE
improve(tests): add type hints for fixtures

### DIFF
--- a/tests/test_config/test_runtime_config.py
+++ b/tests/test_config/test_runtime_config.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+
+import pytest
+
 from src.config.runtime_config import ConfigManager
 
 
@@ -54,7 +57,9 @@ def test_hot_reload_and_rollback() -> None:
     assert events[-1] == 2000
 
 
-def test_env_overrides_and_device_detection(monkeypatch) -> None:
+def test_env_overrides_and_device_detection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     called: dict[str, str] = {}
 
     def fake_detect(pref: str) -> str:

--- a/tests/test_config/test_runtime_config_errors.py
+++ b/tests/test_config/test_runtime_config_errors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from src.config.runtime_config import ConfigManager, ValidationEngine
@@ -7,7 +9,7 @@ def invalid_validator(cfg):
     return False, {"top_k": "invalid"}
 
 
-def test_invalid_runtime_overrides_raise():
+def test_invalid_runtime_overrides_raise() -> None:
     cm = ConfigManager(
         base_config={
             "top_k": 1,

--- a/tests/test_monitoring/test_performance.py
+++ b/tests/test_monitoring/test_performance.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import time
 import tracemalloc
@@ -11,7 +13,9 @@ from src.monitoring.performance import (
 )
 
 
-def test_performance_tracker_alert(monkeypatch, caplog):
+def test_performance_tracker_alert(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     caplog.set_level(logging.WARNING, logger="src.monitoring.performance")
     times = [0, 2.0]
     monkeypatch.setattr(time, "perf_counter", lambda: times.pop(0))
@@ -32,7 +36,7 @@ def test_performance_tracker_alert(monkeypatch, caplog):
     assert "performance" in caplog.text
 
 
-def test_model_cache_cleanup():
+def test_model_cache_cleanup() -> None:
     cache = ModelCache(max_items=1)
     cache.get("a", lambda: object())
     assert cache.keys() == ["a"]
@@ -41,8 +45,8 @@ def test_model_cache_cleanup():
 
 
 def _run_latency(
-    monkeypatch,
-    dashboard,
+    monkeypatch: pytest.MonkeyPatch,
+    dashboard: MetricsDashboard,
     latency_ms: float,
     mode: str = "dense",
 ) -> None:
@@ -52,7 +56,7 @@ def _run_latency(
         pass
 
 
-def test_p95_latency_calculation(monkeypatch):
+def test_p95_latency_calculation(monkeypatch: pytest.MonkeyPatch) -> None:
     dashboard = MetricsDashboard(window_size=5)
     monkeypatch.setattr(tracemalloc, "start", lambda: None)
     monkeypatch.setattr(tracemalloc, "stop", lambda: None)
@@ -62,7 +66,9 @@ def test_p95_latency_calculation(monkeypatch):
     assert dashboard.p95_latency("dense") == pytest.approx(480.0)
 
 
-def test_p95_latency_warning(monkeypatch, caplog):
+def test_p95_latency_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     dashboard = MetricsDashboard(window_size=5)
     monkeypatch.setattr(tracemalloc, "start", lambda: None)
     monkeypatch.setattr(tracemalloc, "stop", lambda: None)

--- a/tests/test_monitoring/test_tracker_dashboard.py
+++ b/tests/test_monitoring/test_tracker_dashboard.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import time
 import tracemalloc
@@ -7,7 +9,9 @@ import pytest
 from src.monitoring.performance import MetricsDashboard, PerformanceTracker
 
 
-def test_performance_tracker_with_dashboard(monkeypatch, caplog):
+def test_performance_tracker_with_dashboard(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     dashboard = MetricsDashboard()
     caplog.set_level(logging.WARNING, logger="src.monitoring.performance")
     times = [0, 0.2]

--- a/warnings_report.md
+++ b/warnings_report.md
@@ -1,7 +1,7 @@
 # Test Warnings Report
 
-- Generated: 2025-09-07T16:57:43Z
-- Pytest exit status: 0
+- Generated: 2025-09-07T17:04:22Z
+- Pytest exit status: 2
 - Total warnings: 1
 
 ## Warning 1


### PR DESCRIPTION
## Description:
- add `from __future__ import annotations` and `import pytest`
- type monkeypatch and caplog fixtures and MetricsDashboard helper
- annotate test and helper functions with `-> None`

## Testing Done:
- `black src/ tests/ app.py`
- `flake8 src/ tests/ app.py` *(fails: E501 line too long in existing files)*
- `pyright` *(fails: venv .venv subdirectory not found)*
- `python -m pytest tests/ -v` *(interrupted, collected 0 items)*

## Performance Impact:
- None

## Configuration Changes:
- None

## Evaluation Results:
- N/A


------
https://chatgpt.com/codex/tasks/task_e_68bdba1e5c788322b38c96abba85b8d5