### PR TITLE
improve(tests): add annotations and pytest imports

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 from fastapi.testclient import TestClient
 
 from app import app

--- a/tests/test_config/test_backup.py
+++ b/tests/test_config/test_backup.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 from pathlib import Path
 import datetime
 

--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 from pathlib import Path
 
 from src.config.settings import (

--- a/tests/test_config/test_validate.py
+++ b/tests/test_config/test_validate.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 from src.config.validate import validate_settings
 
 

--- a/tests/test_evaluation/test_ragas_integration.py
+++ b/tests/test_evaluation/test_ragas_integration.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 import json
 import datetime
 from unittest.mock import patch
@@ -5,7 +8,7 @@ from unittest.mock import patch
 from src.evaluation.ragas_integration import RagasEvaluator
 
 
-def test_evaluate_records_history(tmp_path):
+def test_evaluate_records_history(tmp_path) -> None:
     file_path = tmp_path / "history.jsonl"
     evaluator = RagasEvaluator(history_path=file_path)
 

--- a/tests/test_evaluation/test_recommendations.py
+++ b/tests/test_evaluation/test_recommendations.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 from src.evaluation.recommendations import (
     RecommendationLogger,
     generate_recommendations,
@@ -6,32 +9,32 @@ from src.ui.evaluate import _load_dashboard, EVALUATOR
 from src.evaluation.ragas_integration import EvaluationResult
 
 
-def test_recommend_low_relevancy():
+def test_recommend_low_relevancy() -> None:
     recs = generate_recommendations({"relevancy": 0.5, "precision": 0.9})
     assert "Expand top-K" in recs
     assert "Enable reranking" not in recs
     assert "Adjust weights" not in recs
 
 
-def test_recommend_low_precision():
+def test_recommend_low_precision() -> None:
     recs = generate_recommendations({"relevancy": 0.9, "precision": 0.6})
     assert "Enable reranking" in recs
     assert "Expand top-K" not in recs
 
 
-def test_recommend_cross_metric():
+def test_recommend_cross_metric() -> None:
     recs = generate_recommendations({"relevancy": 0.6, "precision": 0.6})
     assert "Adjust weights" in recs
     assert "Expand top-K" in recs
     assert "Enable reranking" in recs
 
 
-def test_recommend_low_faithfulness():
+def test_recommend_low_faithfulness() -> None:
     recs = generate_recommendations({"faithfulness": 0.6, "precision": 0.6})
     assert "Adjust weights" in recs
 
 
-def test_logger_records():
+def test_logger_records() -> None:
     logger = RecommendationLogger()
     before = {"relevancy": 0.5}
     after = {"relevancy": 0.8}
@@ -44,7 +47,7 @@ def test_logger_records():
     assert record.after == after
 
 
-def test_logger_records_faithfulness_improvement():
+def test_logger_records_faithfulness_improvement() -> None:
     logger = RecommendationLogger()
     before = {"faithfulness": 0.6, "precision": 0.6}
     after = {"faithfulness": 0.8, "precision": 0.6}
@@ -54,7 +57,7 @@ def test_logger_records_faithfulness_improvement():
     assert record.after["faithfulness"] > record.before["faithfulness"]
 
 
-def test_load_dashboard_recommendations(monkeypatch):
+def test_load_dashboard_recommendations(monkeypatch: pytest.MonkeyPatch) -> None:
     sample_history = [
         EvaluationResult(
             timestamp="2024-01-01T00:00:00",

--- a/tests/test_integrations/test_huggingface_models.py
+++ b/tests/test_integrations/test_huggingface_models.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
+import pytest
 from pathlib import Path
 
 from src.integrations import huggingface_models
 from src.integrations.huggingface_models import HuggingFaceModelManager
 
 
-def test_download_success_tracks_revision(tmp_path, monkeypatch):
+def test_download_success_tracks_revision(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_download(
         repo_id: str,
         revision: str,
@@ -24,7 +27,7 @@ def test_download_success_tracks_revision(tmp_path, monkeypatch):
     assert version_file.read_text() == "123"
 
 
-def test_download_failure_uses_cached_revision(tmp_path, monkeypatch):
+def test_download_failure_uses_cached_revision(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     cached_dir = tmp_path / "test__model"
     cached_dir.mkdir()
     (cached_dir / "revision.txt").write_text("456")
@@ -48,7 +51,7 @@ def test_download_failure_uses_cached_revision(tmp_path, monkeypatch):
     assert Path(path).exists()
 
 
-def test_download_failure_uses_fallback_revision(tmp_path, monkeypatch):
+def test_download_failure_uses_fallback_revision(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_download(
         repo_id: str,
         revision: str,

--- a/tests/test_integrations/test_pinecone_client.py
+++ b/tests/test_integrations/test_pinecone_client.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 import types
 from typing import Any, Dict, List
 
@@ -33,7 +36,7 @@ class FakeIndex:
         return {"matches": []}
 
 
-def test_create_index_retries(monkeypatch):
+def test_create_index_retries(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: Dict[str, int] = {"create": 0, "init": 0}
 
     def fake_init(api_key=None, environment=None):
@@ -65,7 +68,7 @@ def test_create_index_retries(monkeypatch):
     assert calls["init"] == 1
 
 
-def test_delete_index_retries(monkeypatch):
+def test_delete_index_retries(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: Dict[str, int] = {"delete": 0}
 
     def fake_delete_index(name):
@@ -88,7 +91,7 @@ def test_delete_index_retries(monkeypatch):
     assert calls["delete"] == 2
 
 
-def test_upsert_batches_and_retries(monkeypatch):
+def test_upsert_batches_and_retries(monkeypatch: pytest.MonkeyPatch) -> None:
     index = FakeIndex(fail_upsert_times=1)
 
     fake_pinecone = types.SimpleNamespace(
@@ -120,7 +123,7 @@ def test_upsert_batches_and_retries(monkeypatch):
     assert sleep_calls == [1.0, 0.5, 0.5]
 
 
-def test_query_retries(monkeypatch):
+def test_query_retries(monkeypatch: pytest.MonkeyPatch) -> None:
     index = FakeIndex(fail_query_times=1)
 
     fake_pinecone = types.SimpleNamespace(

--- a/tests/test_monitoring/test_auto_tuner.py
+++ b/tests/test_monitoring/test_auto_tuner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from src.config.runtime_config import ConfigManager
 from src.monitoring.auto_tuner import AutoTuner
 from src.monitoring.performance import MetricsDashboard

--- a/tests/test_monitoring/test_policy_management.py
+++ b/tests/test_monitoring/test_policy_management.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from src.config.runtime_config import ConfigManager
 from src.monitoring.auto_tuner import AutoTuner
 from src.monitoring.performance import MetricsDashboard

--- a/tests/test_query_service.py
+++ b/tests/test_query_service.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 from src.query_service import QueryService
 
 
@@ -10,14 +13,14 @@ class StubHybrid:
         return [], {}
 
 
-def test_query_service_defaults_to_hybrid():
+def test_query_service_defaults_to_hybrid() -> None:
     stub = StubHybrid()
     service = QueryService(stub)
     service.query("hello")
     assert stub.last_mode == "hybrid"
 
 
-def test_query_service_mode_override():
+def test_query_service_mode_override() -> None:
     stub = StubHybrid()
     service = QueryService(stub)
     service.query("hello", mode="lexical")

--- a/tests/test_ranking/test_reranker.py
+++ b/tests/test_ranking/test_reranker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 
 import pytest
@@ -8,7 +10,7 @@ def _build_docs(ids):
     return [{"id": i, "text": f"text {i}"} for i in ids]
 
 
-def test_reranker_orders_by_score(monkeypatch):
+def test_reranker_orders_by_score(monkeypatch: pytest.MonkeyPatch) -> None:
     reranker = CrossEncoderReranker(load_model=False)
 
     def fake_scores(query, texts):
@@ -21,7 +23,7 @@ def test_reranker_orders_by_score(monkeypatch):
     assert meta["reranked"]
 
 
-def test_reranker_timeout_fallback(monkeypatch):
+def test_reranker_timeout_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     reranker = CrossEncoderReranker(load_model=False)
 
     def slow_scores(query, texts):
@@ -42,7 +44,7 @@ def test_reranker_timeout_fallback(monkeypatch):
 
 
 @pytest.mark.skip(reason="benchmark fixture not available")
-def test_reranker_benchmark(benchmark):
+def test_reranker_benchmark(benchmark) -> None:
     reranker = CrossEncoderReranker(load_model=False)
 
     def zero_scores(q, texts):
@@ -57,11 +59,11 @@ def test_reranker_benchmark(benchmark):
     benchmark(run)
 
 
-def test_reranker_falls_back_to_cpu_when_xpu_missing():
+def test_reranker_falls_back_to_cpu_when_xpu_missing() -> None:
     reranker = CrossEncoderReranker(load_model=False, device="gpu_xpu")
     assert reranker.device == "cpu"
 
 
-def test_reranker_falls_back_to_cpu_when_openvino_missing():
+def test_reranker_falls_back_to_cpu_when_openvino_missing() -> None:
     reranker = CrossEncoderReranker(load_model=False, device="gpu_openvino")
     assert reranker.device == "cpu"

--- a/tests/test_ranking/test_rrf.py
+++ b/tests/test_ranking/test_rrf.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 import math
 
 from src.ranking.rrf_fusion import DEFAULT_RRF_K, rrf_fusion

--- a/tests/test_retrieval/test_dense.py
+++ b/tests/test_retrieval/test_dense.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -19,7 +22,7 @@ class MockPineconeClient:
 
 
 @patch("src.retrieval.dense.SentenceTransformer")
-def test_embed_query_returns_dimension(mock_model):
+def test_embed_query_returns_dimension(mock_model) -> None:
     mock_instance = MagicMock()
     dim_attr = mock_instance.get_sentence_embedding_dimension
     dim_attr.return_value = EMBEDDING_DIMENSION
@@ -34,7 +37,7 @@ def test_embed_query_returns_dimension(mock_model):
 
 
 @patch("src.retrieval.dense.SentenceTransformer")
-def test_index_corpus_upserts_vectors(mock_model):
+def test_index_corpus_upserts_vectors(mock_model) -> None:
     mock_instance = MagicMock()
     dim_attr = mock_instance.get_sentence_embedding_dimension
     dim_attr.return_value = EMBEDDING_DIMENSION
@@ -56,7 +59,7 @@ def test_index_corpus_upserts_vectors(mock_model):
 
 
 @patch("src.retrieval.dense.SentenceTransformer")
-def test_xpu_device_uses_xpu_backend(mock_model):
+def test_xpu_device_uses_xpu_backend(mock_model) -> None:
     mock_instance = MagicMock()
     mock_instance.get_sentence_embedding_dimension.return_value = EMBEDDING_DIMENSION
     mock_model.return_value = mock_instance
@@ -67,7 +70,7 @@ def test_xpu_device_uses_xpu_backend(mock_model):
     mock_model.assert_called_with("all-MiniLM-L6-v2", device="xpu")
 
 
-def test_openvino_device_uses_compile(monkeypatch):
+def test_openvino_device_uses_compile(monkeypatch: pytest.MonkeyPatch) -> None:
     core_instance = MagicMock()
     core_instance.compile_model.return_value = MagicMock()
     core_cls = MagicMock(return_value=core_instance)

--- a/tests/test_retrieval/test_hybrid.py
+++ b/tests/test_retrieval/test_hybrid.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 from src.retrieval.hybrid import HybridRetriever
 
 
@@ -11,7 +14,7 @@ class StubLexical:
         return [("b", 1.0), ("c", 0.5)], {"retrieved": 2}
 
 
-def test_hybrid_rrf_merges_and_tags_sources():
+def test_hybrid_rrf_merges_and_tags_sources() -> None:
     hybrid = HybridRetriever(StubDense(), StubLexical())
     results, meta = hybrid.query("test")
     assert results[0]["id"] == "b"
@@ -21,7 +24,7 @@ def test_hybrid_rrf_merges_and_tags_sources():
     assert "component_scores" in meta
 
 
-def test_mode_selection_dense_and_lexical():
+def test_mode_selection_dense_and_lexical() -> None:
     hybrid = HybridRetriever(StubDense(), StubLexical())
     dense_only, _ = hybrid.query("test", mode="dense")
     assert all(r["source"] == "dense" for r in dense_only)
@@ -37,14 +40,14 @@ def _build_hybrid_with_lexical_corpus():
     return HybridRetriever(StubDense(), lex)
 
 
-def test_common_language_query_keeps_default_weights():
+def test_common_language_query_keeps_default_weights() -> None:
     hybrid = _build_hybrid_with_lexical_corpus()
     _, meta = hybrid.query("alpha beta")
     assert meta["rrf_weights"]["dense"] == 1.0
     assert meta["rrf_weights"]["lexical"] == 1.0
 
 
-def test_rare_token_query_shifts_toward_lexical():
+def test_rare_token_query_shifts_toward_lexical() -> None:
     hybrid = _build_hybrid_with_lexical_corpus()
     _, meta = hybrid.query("AB-123 malfunction")
     assert meta["rrf_weights"]["lexical"] > meta["rrf_weights"]["dense"]

--- a/tests/test_retrieval/test_hybrid_rerank.py
+++ b/tests/test_retrieval/test_hybrid_rerank.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 from src.retrieval.hybrid import HybridRetriever
 
 
@@ -21,7 +24,7 @@ class StubReranker:
         return docs[:top_k], {"reranked": True, "latency_ms": 1}
 
 
-def test_hybrid_rerank_integration():
+def test_hybrid_rerank_integration() -> None:
     hybrid = HybridRetriever(
         StubDense(),
         StubLexical(),

--- a/tests/test_retrieval/test_lexical.py
+++ b/tests/test_retrieval/test_lexical.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
+import pytest
 from src.retrieval.lexical import LexicalBM25
 
 
-def test_index_and_query_returns_scores():
+def test_index_and_query_returns_scores() -> None:
     retriever = LexicalBM25()
     ids, meta = retriever.index_documents(
         [
@@ -16,7 +19,7 @@ def test_index_and_query_returns_scores():
     assert any(score > 0 for _, score in results)
 
 
-def test_index_update_adds_documents():
+def test_index_update_adds_documents() -> None:
     retriever = LexicalBM25()
     retriever.index_documents(["first doc"])
     retriever.index_documents(["second doc", "third doc"])
@@ -25,7 +28,7 @@ def test_index_update_adds_documents():
     assert results[0][0] == "2"
 
 
-def test_stemming_enables_root_match():
+def test_stemming_enables_root_match() -> None:
     retriever = LexicalBM25(enable_stemming=True)
     retriever.index_documents(
         [
@@ -38,7 +41,7 @@ def test_stemming_enables_root_match():
     assert results[0][1] > 0
 
 
-def test_without_stemming_no_match():
+def test_without_stemming_no_match() -> None:
     retriever = LexicalBM25()
     retriever.index_documents(["running fast"])
     results, _ = retriever.query("run")

--- a/tests/test_retrieval/test_query_analysis.py
+++ b/tests/test_retrieval/test_query_analysis.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 import types
 
 from src.retrieval.query_analysis import analyze_query
@@ -8,7 +11,7 @@ class DummyLexical:
         self.bm25 = types.SimpleNamespace(idf=idf)
 
 
-def test_analyze_query_detects_identifier():
+def test_analyze_query_detects_identifier() -> None:
     lexical = DummyLexical({})
     weights, meta = analyze_query("find AB-123", lexical)
     assert weights["w_dense"] < 1.0
@@ -16,7 +19,7 @@ def test_analyze_query_detects_identifier():
     assert meta["rrf_weights"]["lexical"] == weights["w_lexical"]
 
 
-def test_analyze_query_uses_idf_scores():
+def test_analyze_query_uses_idf_scores() -> None:
     lexical = DummyLexical({"rare": 4.0, "token": 4.0})
     weights, _ = analyze_query("rare token", lexical)
     assert weights["w_dense"] < 1.0

--- a/tests/test_services/test_document_service.py
+++ b/tests/test_services/test_document_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib.util
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -45,7 +47,7 @@ def create_docx(path: Path) -> None:
     doc.save(path)
 
 
-def test_parse_various_formats(tmp_path, mocks):
+def test_parse_various_formats(tmp_path, mocks) -> None:
     dense, lexical = mocks
     service = DocumentService(dense, lexical)
 
@@ -73,7 +75,7 @@ def test_parse_various_formats(tmp_path, mocks):
         assert "Hello DOCX" in service.parse_document(str(docx_file))
 
 
-def test_chunk_and_ingest(tmp_path, mocks):
+def test_chunk_and_ingest(tmp_path, mocks) -> None:
     dense, lexical = mocks
     service = DocumentService(dense, lexical, chunk_size=3, overlap=1)
     file = tmp_path / "text.txt"
@@ -88,7 +90,7 @@ def test_chunk_and_ingest(tmp_path, mocks):
     assert result["chunk_count"] == 2
 
 
-def test_ingest_progress_callback(tmp_path, mocks):
+def test_ingest_progress_callback(tmp_path, mocks) -> None:
     dense, lexical = mocks
     service = DocumentService(dense, lexical, chunk_size=3, overlap=1)
     file = tmp_path / "text.txt"
@@ -104,7 +106,7 @@ def test_ingest_progress_callback(tmp_path, mocks):
     assert any("Indexing lexical" in s for s in steps)
 
 
-def test_update_delete_and_audit(mocks):
+def test_update_delete_and_audit(mocks) -> None:
     dense, lexical = mocks
     service = DocumentService(dense, lexical)
 
@@ -120,7 +122,7 @@ def test_update_delete_and_audit(mocks):
     assert [entry["action"] for entry in audit] == ["update", "delete"]
 
 
-def test_bulk_operations_audit(mocks):
+def test_bulk_operations_audit(mocks) -> None:
     dense, lexical = mocks
     service = DocumentService(dense, lexical)
 

--- a/tests/test_services/test_index_management.py
+++ b/tests/test_services/test_index_management.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 import json
 import datetime
 from typing import Any, Dict
@@ -43,7 +46,7 @@ def build_manager():
     return IndexManagement(DummyDense(), DummyLexical())
 
 
-def test_update_and_delete_record_audit():
+def test_update_and_delete_record_audit() -> None:
     mgr = build_manager()
     mgr.update_document("1", "doc", {})
     mgr.delete_document("1")
@@ -57,7 +60,7 @@ def test_update_and_delete_record_audit():
     assert timestamps == sorted(timestamps)
 
 
-def test_bulk_operations_and_error():
+def test_bulk_operations_and_error() -> None:
     mgr = build_manager()
     ops = [
         {"action": "update", "doc_id": "1", "content": "a"},
@@ -68,14 +71,14 @@ def test_bulk_operations_and_error():
     assert result["results"][-1]["result"]["status"] == "error"
 
 
-def test_index_health_check_reports_status():
+def test_index_health_check_reports_status() -> None:
     mgr = build_manager()
     health = mgr.index_health_check()
     assert health["dense"]["valid"]
     assert health["lexical"]["ready"]
 
 
-def test_log_retrieval_records_and_exports(tmp_path):
+def test_log_retrieval_records_and_exports(tmp_path) -> None:
     mgr = build_manager()
     meta = {
         "retrieval_mode": "hybrid",

--- a/tests/test_ui/test_chat.py
+++ b/tests/test_ui/test_chat.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 import json
 
 import gradio as gr
@@ -11,11 +14,11 @@ from src.ui.chat import (
 )
 
 
-def test_sanitize_html():
+def test_sanitize_html() -> None:
     assert _sanitize(" <b>hi</b> ") == "&lt;b&gt;hi&lt;/b&gt;"
 
 
-def test_append_history_writes(tmp_path):
+def test_append_history_writes(tmp_path) -> None:
     file_path = tmp_path / "history.jsonl"
     original = HISTORY_PATH
     try:
@@ -37,7 +40,7 @@ def test_append_history_writes(tmp_path):
         chat.HISTORY_PATH = original
 
 
-def test_generate_response_streams(tmp_path):
+def test_generate_response_streams(tmp_path) -> None:
     file_path = tmp_path / "history.jsonl"
     from src.ui import chat
 
@@ -82,6 +85,6 @@ def test_generate_response_streams(tmp_path):
     chat.EVALUATOR.evaluate = original_evaluate
 
 
-def test_chat_page_has_chat_interface():
+def test_chat_page_has_chat_interface() -> None:
     page = chat_page()
     assert any(isinstance(b, gr.Chatbot) for b in page.blocks.values())

--- a/tests/test_ui/test_evaluate.py
+++ b/tests/test_ui/test_evaluate.py
@@ -1,7 +1,9 @@
 """Tests for the evaluation dashboard UI."""
 
-import datetime
+from __future__ import annotations
 
+import pytest
+import datetime
 import gradio as gr
 
 from src.evaluation.ragas_integration import EvaluationResult
@@ -9,7 +11,7 @@ from src.ui.evaluate import EVALUATOR, _load_dashboard, evaluate_page
 from src.config.runtime_config import config_manager
 
 
-def test_evaluate_page_has_components():
+def test_evaluate_page_has_components() -> None:
     page = evaluate_page()
     blocks = list(page.blocks.values())
     assert any(isinstance(b, gr.Plot) for b in blocks)
@@ -25,7 +27,7 @@ def test_evaluate_page_has_components():
     )
 
 
-def test_load_dashboard_filters_and_exports(monkeypatch):
+def test_load_dashboard_filters_and_exports(monkeypatch: pytest.MonkeyPatch) -> None:
     now = datetime.datetime.now(datetime.UTC)
     records = [
         EvaluationResult(
@@ -83,7 +85,7 @@ def test_load_dashboard_filters_and_exports(monkeypatch):
     assert "Expand top-K" in recs
 
 
-def test_alerts_use_thresholds(monkeypatch):
+def test_alerts_use_thresholds(monkeypatch: pytest.MonkeyPatch) -> None:
     now = datetime.datetime.now(datetime.UTC)
     records = [
         EvaluationResult(

--- a/tests/test_ui/test_gradio_integration.py
+++ b/tests/test_ui/test_gradio_integration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from src.ui.chat import chat_page
@@ -9,7 +11,7 @@ except Exception:  # pragma: no cover
 
 
 @pytest.mark.skipif(TestClient is None, reason="no TestClient")
-def test_chat_page_interaction():
+def test_chat_page_interaction() -> None:
     client = TestClient(chat_page())
     result = client.chat("hello")
     assert "You said" in result[0]

--- a/tests/test_ui/test_ingest.py
+++ b/tests/test_ui/test_ingest.py
@@ -1,5 +1,8 @@
 """Tests for ingest page UI."""
 
+from __future__ import annotations
+
+import pytest
 import gradio as gr
 
 from src.ui import ingest as ingest_module
@@ -10,7 +13,7 @@ class DummyFile:
         self.name = name
 
 
-def test_ingest_page_has_components():
+def test_ingest_page_has_components() -> None:
     page = ingest_module.ingest_page()
     blocks = list(page.blocks.values())
     assert any(isinstance(b, gr.File) for b in blocks)
@@ -23,7 +26,7 @@ def test_ingest_page_has_components():
     assert {"Process All", "Update", "Delete", "Health Check"} <= button_labels
 
 
-def test_callbacks_invoked(monkeypatch, tmp_path):
+def test_callbacks_invoked(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     calls: dict[str, object] = {}
 
     class DummyIndex:
@@ -96,7 +99,7 @@ def test_callbacks_invoked(monkeypatch, tmp_path):
     assert "update" in calls and "delete" in calls
 
 
-def test_failed_ingest_shows_error(monkeypatch, tmp_path):
+def test_failed_ingest_shows_error(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     class FailingService:
         def parse_document(self, _path):
             raise ValueError("bad file")
@@ -115,7 +118,7 @@ def test_failed_ingest_shows_error(monkeypatch, tmp_path):
     assert alert["visible"] is True
 
 
-def test_progress_callback_updates_components(tmp_path):
+def test_progress_callback_updates_components(tmp_path) -> None:
     from unittest.mock import MagicMock
 
     dense = MagicMock()

--- a/tests/test_ui/test_ingest_queue.py
+++ b/tests/test_ui/test_ingest_queue.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 from src.ui.ingest import _queue_files, _process_all, _document_service
 
 
@@ -6,7 +9,7 @@ class DummyFile:
         self.name = name
 
 
-def test_queue_and_process(tmp_path, monkeypatch):
+def test_queue_and_process(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     file_path = tmp_path / "doc.txt"
     file_path.write_text("hello world")
 

--- a/tests/test_ui/test_performance_indicator.py
+++ b/tests/test_ui/test_performance_indicator.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
+import pytest
 import gradio as gr
 
 from src.ui.components.transparency import PerformanceIndicator
 
 
-def test_performance_indicator_updates_latency():
+def test_performance_indicator_updates_latency() -> None:
     with gr.Blocks():
         perf = PerformanceIndicator()
         md = perf.render()

--- a/tests/test_ui/test_ranking_controls.py
+++ b/tests/test_ui/test_ranking_controls.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
+import pytest
 import gradio as gr
 from src.ui.components.ranking_controls import RankingControls
 
 
-def test_ranking_controls_update_state():
+def test_ranking_controls_update_state() -> None:
     with gr.Blocks():
         controls = RankingControls().render()
         controls.bind()
@@ -13,7 +16,7 @@ def test_ranking_controls_update_state():
     assert state["enable_rerank"] is True
 
 
-def test_ranking_controls_validation_clamps_values():
+def test_ranking_controls_validation_clamps_values() -> None:
     with gr.Blocks():
         controls = RankingControls().render()
     state = controls.update_state(0, -1.0, 3.0, False)
@@ -23,7 +26,7 @@ def test_ranking_controls_validation_clamps_values():
     assert state["enable_rerank"] is False
 
 
-def test_ranking_controls_initial_state_defaults():
+def test_ranking_controls_initial_state_defaults() -> None:
     rc = RankingControls()
     assert rc.state.value["rrf_k"] == 60
     assert rc.state.value["enable_rerank"] is False

--- a/tests/test_ui/test_settings_performance.py
+++ b/tests/test_ui/test_settings_performance.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 import gradio as gr
 from gradio.components import JSON
 
@@ -10,7 +13,7 @@ from src.ui.chat import QUERY_SERVICE
 from src.config.runtime_config import config_manager
 
 
-def test_performance_tab_displays_metrics():
+def test_performance_tab_displays_metrics() -> None:
     dashboard = QUERY_SERVICE.dashboard
     dashboard.record_latency("hybrid", 100)
     dashboard.record_latency("hybrid", 200)
@@ -20,7 +23,7 @@ def test_performance_tab_displays_metrics():
     assert "hybrid" in metrics
 
 
-def test_manual_overrides_update_config_manager():
+def test_manual_overrides_update_config_manager() -> None:
     original = config_manager.as_dict()
     settings = original
     settings, _ = update_policy_field("target_p95_ms", 2500, settings)

--- a/tests/test_ui/test_transparency.py
+++ b/tests/test_ui/test_transparency.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pytest
 import gradio as gr
 from gradio.events import EventData
 from unittest.mock import patch
@@ -10,20 +13,20 @@ from src.ui.components.transparency import (
 )
 
 
-def test_citation_badge_click_returns_label():
+def test_citation_badge_click_returns_label() -> None:
     badge = CitationBadge("Doc1")
     evt = EventData(_data={}, target="Doc1")
     assert badge.on_click(evt) == "Doc1"
 
 
-def test_details_drawer_toggle():
+def test_details_drawer_toggle() -> None:
     drawer = DetailsDrawer()
     evt = EventData(_data={}, target=None)
     assert drawer.toggle(evt) is True
     assert drawer.toggle(evt) is False
 
 
-def test_transparency_panel_update_renders_metadata():
+def test_transparency_panel_update_renders_metadata() -> None:
     meta = {
         "citations": [{"label": "Doc1", "source": "dense"}],
         "component_scores": {

--- a/warnings_report.md
+++ b/warnings_report.md
@@ -1,6 +1,6 @@
 # Test Warnings Report
 
-- Generated: 2025-09-07T17:10:05Z
+- Generated: 2025-09-07T21:39:24Z
 - Pytest exit status: 0
 - Total warnings: 1
 


### PR DESCRIPTION
## Description:
- add `from __future__ import annotations` and `import pytest` to test modules
- annotate `monkeypatch` fixtures as `pytest.MonkeyPatch`
- add explicit `-> None` return types for test functions

## Testing Done:
- `python -m pytest tests/ -v`

## Performance Impact:
- n/a

## Configuration Changes:
- n/a

## Evaluation Results:
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68bdfae47db88322895f5fc0166c9215