### PR TITLE
improve(tests): annotate pytest fixtures

### DIFF
--- a/tests/test_evaluation/test_ragas_integration.py
+++ b/tests/test_evaluation/test_ragas_integration.py
@@ -4,11 +4,12 @@ import pytest
 import json
 import datetime
 from unittest.mock import patch
+from pathlib import Path
 
 from src.evaluation.ragas_integration import RagasEvaluator
 
 
-def test_evaluate_records_history(tmp_path) -> None:
+def test_evaluate_records_history(tmp_path: Path) -> None:
     file_path = tmp_path / "history.jsonl"
     evaluator = RagasEvaluator(history_path=file_path)
 

--- a/tests/test_integrations/test_huggingface_models.py
+++ b/tests/test_integrations/test_huggingface_models.py
@@ -7,7 +7,9 @@ from src.integrations import huggingface_models
 from src.integrations.huggingface_models import HuggingFaceModelManager
 
 
-def test_download_success_tracks_revision(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_download_success_tracks_revision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     def fake_download(
         repo_id: str,
         revision: str,
@@ -27,7 +29,9 @@ def test_download_success_tracks_revision(tmp_path, monkeypatch: pytest.MonkeyPa
     assert version_file.read_text() == "123"
 
 
-def test_download_failure_uses_cached_revision(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_download_failure_uses_cached_revision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     cached_dir = tmp_path / "test__model"
     cached_dir.mkdir()
     (cached_dir / "revision.txt").write_text("456")
@@ -51,7 +55,9 @@ def test_download_failure_uses_cached_revision(tmp_path, monkeypatch: pytest.Mon
     assert Path(path).exists()
 
 
-def test_download_failure_uses_fallback_revision(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_download_failure_uses_fallback_revision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     def fake_download(
         repo_id: str,
         revision: str,

--- a/tests/test_services/test_document_service.py
+++ b/tests/test_services/test_document_service.py
@@ -47,7 +47,7 @@ def create_docx(path: Path) -> None:
     doc.save(path)
 
 
-def test_parse_various_formats(tmp_path, mocks) -> None:
+def test_parse_various_formats(tmp_path: Path, mocks) -> None:
     dense, lexical = mocks
     service = DocumentService(dense, lexical)
 
@@ -75,7 +75,7 @@ def test_parse_various_formats(tmp_path, mocks) -> None:
         assert "Hello DOCX" in service.parse_document(str(docx_file))
 
 
-def test_chunk_and_ingest(tmp_path, mocks) -> None:
+def test_chunk_and_ingest(tmp_path: Path, mocks) -> None:
     dense, lexical = mocks
     service = DocumentService(dense, lexical, chunk_size=3, overlap=1)
     file = tmp_path / "text.txt"
@@ -90,7 +90,7 @@ def test_chunk_and_ingest(tmp_path, mocks) -> None:
     assert result["chunk_count"] == 2
 
 
-def test_ingest_progress_callback(tmp_path, mocks) -> None:
+def test_ingest_progress_callback(tmp_path: Path, mocks) -> None:
     dense, lexical = mocks
     service = DocumentService(dense, lexical, chunk_size=3, overlap=1)
     file = tmp_path / "text.txt"

--- a/tests/test_services/test_index_management.py
+++ b/tests/test_services/test_index_management.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 import json
 import datetime
+from pathlib import Path
 from typing import Any, Dict
 
 from src.services.index_management import IndexManagement
@@ -78,7 +79,7 @@ def test_index_health_check_reports_status() -> None:
     assert health["lexical"]["ready"]
 
 
-def test_log_retrieval_records_and_exports(tmp_path) -> None:
+def test_log_retrieval_records_and_exports(tmp_path: Path) -> None:
     mgr = build_manager()
     meta = {
         "retrieval_mode": "hybrid",

--- a/tests/test_ui/test_chat.py
+++ b/tests/test_ui/test_chat.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 import json
+from pathlib import Path
 
 import gradio as gr
 
@@ -18,7 +19,7 @@ def test_sanitize_html() -> None:
     assert _sanitize(" <b>hi</b> ") == "&lt;b&gt;hi&lt;/b&gt;"
 
 
-def test_append_history_writes(tmp_path) -> None:
+def test_append_history_writes(tmp_path: Path) -> None:
     file_path = tmp_path / "history.jsonl"
     original = HISTORY_PATH
     try:
@@ -40,7 +41,7 @@ def test_append_history_writes(tmp_path) -> None:
         chat.HISTORY_PATH = original
 
 
-def test_generate_response_streams(tmp_path) -> None:
+def test_generate_response_streams(tmp_path: Path) -> None:
     file_path = tmp_path / "history.jsonl"
     from src.ui import chat
 

--- a/tests/test_ui/test_ingest.py
+++ b/tests/test_ui/test_ingest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from pathlib import Path
 import gradio as gr
 
 from src.ui import ingest as ingest_module
@@ -26,7 +27,9 @@ def test_ingest_page_has_components() -> None:
     assert {"Process All", "Update", "Delete", "Health Check"} <= button_labels
 
 
-def test_callbacks_invoked(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+def test_callbacks_invoked(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     calls: dict[str, object] = {}
 
     class DummyIndex:
@@ -99,7 +102,9 @@ def test_callbacks_invoked(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     assert "update" in calls and "delete" in calls
 
 
-def test_failed_ingest_shows_error(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+def test_failed_ingest_shows_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     class FailingService:
         def parse_document(self, _path):
             raise ValueError("bad file")
@@ -118,7 +123,7 @@ def test_failed_ingest_shows_error(monkeypatch: pytest.MonkeyPatch, tmp_path) ->
     assert alert["visible"] is True
 
 
-def test_progress_callback_updates_components(tmp_path) -> None:
+def test_progress_callback_updates_components(tmp_path: Path) -> None:
     from unittest.mock import MagicMock
 
     dense = MagicMock()

--- a/tests/test_ui/test_ingest_queue.py
+++ b/tests/test_ui/test_ingest_queue.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from pathlib import Path
 from src.ui.ingest import _queue_files, _process_all, _document_service
 
 
@@ -9,7 +10,9 @@ class DummyFile:
         self.name = name
 
 
-def test_queue_and_process(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_queue_and_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     file_path = tmp_path / "doc.txt"
     file_path.write_text("hello world")
 


### PR DESCRIPTION
## Description:
Typed tmp_path and monkeypatch fixtures across tests, ensuring future annotations and pytest imports remain consistent.

## Testing Done:
- `python -m pytest tests/ -v`

## Performance Impact:
None.

## Configuration Changes:
None.

## Evaluation Results:
N/A

------
https://chatgpt.com/codex/tasks/task_e_68bdfbf746488322bcb28d45d0e2195e