### PR TITLE
fix(pyright): remove hardcoded venv settings

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,8 +1,23 @@
 {
   "typeCheckingMode": "strict",
   "pythonVersion": "3.12",
-  "venvPath": ".",
-  "venv": ".venv",
-  "include": ["src", "app.py", "tests"],
-  "exclude": [".venv", ".git", "node_modules", "**/__pycache__"]
+  "include": [
+    "src",
+    "app.py",
+    "tests"
+  ],
+  "exclude": [
+    ".venv",
+    ".git",
+    "node_modules",
+    "**/__pycache__"
+  ],
+  "executionEnvironments": [
+    {
+      "root": ".",
+      "extraPaths": [
+        "./src"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Description:
Removed `venvPath`/`venv` from `pyrightconfig.json` and added an execution environment pointing at `src` so Pyright no longer fails when the repo-local virtual environment is absent.

## Testing Done:
- `pyright --project pyrightconfig.json --outputjson`
- `python -m pytest tests/ -v`

## Performance Impact:
None.

## Configuration Changes:
Updated Pyright configuration to rely on the ambient interpreter and defined execution environments.

## Evaluation Results:
N/A


------
https://chatgpt.com/codex/tasks/task_e_68be04182bbc8322935cd0b22d0fd83c