### PR TITLE
improve(pyright): add baseline diagnostics

### DIFF
--- a/reports/pyright/baseline.output.json
+++ b/reports/pyright/baseline.output.json
@@ -1,0 +1,11758 @@
+{
+    "version": "1.1.405",
+    "time": "1757285502665",
+    "generalDiagnostics": [
+        {
+            "file": "/workspace/personal-rag-copilot/app.py",
+            "severity": "error",
+            "message": "Type of \"mount_gradio_app\" is partially unknown\n  Type of \"mount_gradio_app\" is \"(app: FastAPI, blocks: Blocks, path: str, server_name: str = \"0.0.0.0\", server_port: int = 7860, show_api: bool | None = None, app_kwargs: dict[str, Any] | None = None, *, auth: ((...) -> Unknown) | tuple[str, str] | list[tuple[str, str]] | None = None, auth_message: str | None = None, auth_dependency: ((Request) -> (str | None)) | None = None, root_path: str | None = None, allowed_paths: list[str] | None = None, blocked_paths: list[str] | None = None, favicon_path: str | None = None, show_error: bool = True, max_file_size: str | int | None = None, ssr_mode: bool | None = None, node_server_name: str | None = None, node_port: int | None = None, enable_monitoring: bool | None = None, pwa: bool | None = None, i18n: I18n | None = None, mcp_server: bool | None = None) -> FastAPI\"",
+            "range": {
+                "start": {
+                    "line": 3,
+                    "character": 26
+                },
+                "end": {
+                    "line": 3,
+                    "character": 42
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/__init__.py",
+            "severity": "error",
+            "message": "Type of \"backup_config\" is partially unknown\n  Type of \"backup_config\" is \"(path: str, backup_dir: str) -> Tuple[Path, dict[Unknown, Unknown]]\"",
+            "range": {
+                "start": {
+                    "line": 4,
+                    "character": 20
+                },
+                "end": {
+                    "line": 4,
+                    "character": 33
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/__init__.py",
+            "severity": "error",
+            "message": "Type of \"restore_config\" is partially unknown\n  Type of \"restore_config\" is \"(backup_path: str, target_path: str) -> Tuple[Path, dict[Unknown, Unknown]]\"",
+            "range": {
+                "start": {
+                    "line": 4,
+                    "character": 35
+                },
+                "end": {
+                    "line": 4,
+                    "character": 49
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/backup.py",
+            "severity": "error",
+            "message": "Return type, \"Tuple[Path, dict[Unknown, Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 10,
+                    "character": 4
+                },
+                "end": {
+                    "line": 10,
+                    "character": 17
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/backup.py",
+            "severity": "error",
+            "message": "Expected type arguments for generic class \"dict\"",
+            "range": {
+                "start": {
+                    "line": 10,
+                    "character": 61
+                },
+                "end": {
+                    "line": 10,
+                    "character": 65
+                }
+            },
+            "rule": "reportMissingTypeArgument"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/backup.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[Path, dict[Unknown, Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 18,
+                    "character": 11
+                },
+                "end": {
+                    "line": 18,
+                    "character": 47
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/backup.py",
+            "severity": "error",
+            "message": "Return type, \"Tuple[Path, dict[Unknown, Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 21,
+                    "character": 4
+                },
+                "end": {
+                    "line": 21,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/backup.py",
+            "severity": "error",
+            "message": "Expected type arguments for generic class \"dict\"",
+            "range": {
+                "start": {
+                    "line": 21,
+                    "character": 70
+                },
+                "end": {
+                    "line": 21,
+                    "character": 74
+                }
+            },
+            "rule": "reportMissingTypeArgument"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/backup.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[Path, dict[Unknown, Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 27,
+                    "character": 11
+                },
+                "end": {
+                    "line": 27,
+                    "character": 42
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/runtime_config.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"updates\" in function \"_deep_merge\"\n  Argument type is \"dict[Unknown, Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 19,
+                    "character": 55
+                },
+                "end": {
+                    "line": 19,
+                    "character": 60
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/settings.py",
+            "severity": "error",
+            "message": "Type of \"value\" is partially unknown\n  Type of \"value\" is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 69,
+                    "character": 8
+                },
+                "end": {
+                    "line": 69,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/settings.py",
+            "severity": "error",
+            "message": "Type of \"get\" is partially unknown\n  Type of \"get\" is \"Overload[(key: Unknown, default: None = None, /) -> (Unknown | None), (key: Unknown, default: Unknown, /) -> Unknown, (key: Unknown, default: _T@get, /) -> (Unknown | _T@get)]\"",
+            "range": {
+                "start": {
+                    "line": 69,
+                    "character": 16
+                },
+                "end": {
+                    "line": 69,
+                    "character": 30
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/settings.py",
+            "severity": "error",
+            "message": "Type of \"value\" is partially unknown\n  Type of \"value\" is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 96,
+                    "character": 8
+                },
+                "end": {
+                    "line": 96,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/settings.py",
+            "severity": "error",
+            "message": "Type of \"get\" is partially unknown\n  Type of \"get\" is \"Overload[(key: Unknown, default: None = None, /) -> (Unknown | None), (key: Unknown, default: Unknown, /) -> Unknown, (key: Unknown, default: _T@get, /) -> (Unknown | _T@get)]\"",
+            "range": {
+                "start": {
+                    "line": 96,
+                    "character": 16
+                },
+                "end": {
+                    "line": 96,
+                    "character": 26
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/settings.py",
+            "severity": "error",
+            "message": "Type of \"auto\" is partially unknown\n  Type of \"auto\" is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 103,
+                    "character": 4
+                },
+                "end": {
+                    "line": 103,
+                    "character": 8
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/settings.py",
+            "severity": "error",
+            "message": "Type of \"get\" is partially unknown\n  Type of \"get\" is \"Overload[(key: Unknown, default: None = None, /) -> (Unknown | None), (key: Unknown, default: Unknown, /) -> Unknown, (key: Unknown, default: _T@get, /) -> (Unknown | _T@get)]\"",
+            "range": {
+                "start": {
+                    "line": 103,
+                    "character": 11
+                },
+                "end": {
+                    "line": 103,
+                    "character": 21
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/settings.py",
+            "severity": "error",
+            "message": "Type of \"data\" is partially unknown\n  Type of \"data\" is \"Any | dict[Unknown, Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 122,
+                    "character": 12
+                },
+                "end": {
+                    "line": 122,
+                    "character": 16
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/settings.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[Any | dict[Unknown, Unknown], dict[str, Any]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 123,
+                    "character": 15
+                },
+                "end": {
+                    "line": 123,
+                    "character": 47
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/settings.py",
+            "severity": "error",
+            "message": "Type of \"update\" is partially unknown\n  Type of \"update\" is \"Overload[(m: SupportsKeysAndGetItem[Unknown, Unknown], /) -> None, (m: SupportsKeysAndGetItem[str, Unknown], /, **kwargs: Unknown) -> None, (m: Iterable[tuple[Unknown, Unknown]], /) -> None, (m: Iterable[tuple[str, Unknown]], /, **kwargs: Unknown) -> None, (**kwargs: Unknown) -> None]\"",
+            "range": {
+                "start": {
+                    "line": 136,
+                    "character": 4
+                },
+                "end": {
+                    "line": 136,
+                    "character": 17
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/settings.py",
+            "severity": "error",
+            "message": "Type of \"update\" is partially unknown\n  Type of \"update\" is \"Overload[(m: SupportsKeysAndGetItem[Unknown, Unknown], /) -> None, (m: SupportsKeysAndGetItem[str, Unknown], /, **kwargs: Unknown) -> None, (m: Iterable[tuple[Unknown, Unknown]], /) -> None, (m: Iterable[tuple[str, Unknown]], /, **kwargs: Unknown) -> None, (**kwargs: Unknown) -> None]\"",
+            "range": {
+                "start": {
+                    "line": 137,
+                    "character": 4
+                },
+                "end": {
+                    "line": 137,
+                    "character": 17
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/settings.py",
+            "severity": "error",
+            "message": "Type of \"update\" is partially unknown\n  Type of \"update\" is \"Overload[(m: SupportsKeysAndGetItem[Unknown, Unknown], /) -> None, (m: SupportsKeysAndGetItem[str, Unknown], /, **kwargs: Unknown) -> None, (m: Iterable[tuple[Unknown, Unknown]], /) -> None, (m: Iterable[tuple[str, Unknown]], /, **kwargs: Unknown) -> None, (**kwargs: Unknown) -> None]\"",
+            "range": {
+                "start": {
+                    "line": 138,
+                    "character": 4
+                },
+                "end": {
+                    "line": 138,
+                    "character": 17
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/validate.py",
+            "severity": "error",
+            "message": "Type of \"current\" is partially unknown\n  Type of \"current\" is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 33,
+                    "character": 8
+                },
+                "end": {
+                    "line": 33,
+                    "character": 15
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/validate.py",
+            "severity": "error",
+            "message": "Type of \"get\" is partially unknown\n  Type of \"get\" is \"Overload[(key: Unknown, default: None = None, /) -> (Unknown | None), (key: Unknown, default: Unknown, /) -> Unknown, (key: Unknown, default: _T@get, /) -> (Unknown | _T@get)]\"",
+            "range": {
+                "start": {
+                    "line": 33,
+                    "character": 18
+                },
+                "end": {
+                    "line": 33,
+                    "character": 29
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/config/validate.py",
+            "severity": "error",
+            "message": "Return type, \"Any | Unknown\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 34,
+                    "character": 11
+                },
+                "end": {
+                    "line": 34,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/evaluation/ragas_integration.py",
+            "severity": "error",
+            "message": "Type of \"evaluate\" is partially unknown\n  Type of \"evaluate\" is \"(dataset: Dataset | EvaluationDataset, metrics: Sequence[Metric] | None = None, llm: BaseRagasLLM | BaseLanguageModel[Unknown] | None = None, embeddings: BaseRagasEmbeddings | BaseRagasEmbedding | Embeddings | None = None, experiment_name: str | None = None, callbacks: list[BaseCallbackHandler] | BaseCallbackManager | None = None, run_config: RunConfig | None = None, token_usage_parser: ((LLMResult | ChatResult) -> TokenUsage) | None = None, raise_exceptions: bool = False, column_map: Dict[str, str] | None = None, show_progress: bool = True, batch_size: int | None = None, _run_id: UUID | None = None, _pbar: tqdm_asyncio[Unknown] | None = None, return_executor: bool = False) -> (EvaluationResult | Executor)\"",
+            "range": {
+                "start": {
+                    "line": 10,
+                    "character": 18
+                },
+                "end": {
+                    "line": 10,
+                    "character": 26
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/evaluation/ragas_integration.py",
+            "severity": "error",
+            "message": "Argument of type \"dict[str, list[str] | list[List[str]]]\" cannot be assigned to parameter \"dataset\" of type \"Dataset | EvaluationDataset\"\n  Type \"dict[str, list[str] | list[List[str]]]\" is not assignable to type \"Dataset | EvaluationDataset\"\n    \"dict[str, list[str] | list[List[str]]]\" is not assignable to \"Dataset\"\n    \"dict[str, list[str] | list[List[str]]]\" is not assignable to \"EvaluationDataset\"",
+            "range": {
+                "start": {
+                    "line": 53,
+                    "character": 16
+                },
+                "end": {
+                    "line": 53,
+                    "character": 20
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/huggingface_models.py",
+            "severity": "error",
+            "message": "Object of type \"None\" cannot be called",
+            "range": {
+                "start": {
+                    "line": 54,
+                    "character": 19
+                },
+                "end": {
+                    "line": 58,
+                    "character": 13
+                }
+            },
+            "rule": "reportOptionalCall"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/huggingface_models.py",
+            "severity": "error",
+            "message": "Object of type \"None\" cannot be called",
+            "range": {
+                "start": {
+                    "line": 71,
+                    "character": 27
+                },
+                "end": {
+                    "line": 76,
+                    "character": 21
+                }
+            },
+            "rule": "reportOptionalCall"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/huggingface_models.py",
+            "severity": "error",
+            "message": "Object of type \"None\" cannot be called",
+            "range": {
+                "start": {
+                    "line": 92,
+                    "character": 27
+                },
+                "end": {
+                    "line": 96,
+                    "character": 21
+                }
+            },
+            "rule": "reportOptionalCall"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Return type, \"Unknown | None\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 8
+                },
+                "end": {
+                    "line": 46,
+                    "character": 21
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"func\" is partially unknown\n  Parameter type is \"(...) -> Unknown\"",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 28
+                },
+                "end": {
+                    "line": 46,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Expected type arguments for generic class \"Callable\"",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 34
+                },
+                "end": {
+                    "line": 46,
+                    "character": 42
+                }
+            },
+            "rule": "reportMissingTypeArgument"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"args\" is unknown",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 45
+                },
+                "end": {
+                    "line": 46,
+                    "character": 49
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"args\"",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 45
+                },
+                "end": {
+                    "line": 46,
+                    "character": 49
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"kwargs\" is unknown",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 53
+                },
+                "end": {
+                    "line": 46,
+                    "character": 59
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"kwargs\"",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 53
+                },
+                "end": {
+                    "line": 46,
+                    "character": 59
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Return type is unknown",
+            "range": {
+                "start": {
+                    "line": 52,
+                    "character": 23
+                },
+                "end": {
+                    "line": 52,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"args\"",
+            "range": {
+                "start": {
+                    "line": 52,
+                    "character": 29
+                },
+                "end": {
+                    "line": 52,
+                    "character": 33
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"kwargs\"",
+            "range": {
+                "start": {
+                    "line": 52,
+                    "character": 37
+                },
+                "end": {
+                    "line": 52,
+                    "character": 43
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"init\" is unknown",
+            "range": {
+                "start": {
+                    "line": 71,
+                    "character": 8
+                },
+                "end": {
+                    "line": 71,
+                    "character": 21
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "\"init\" is not a known attribute of module \"pinecone\"",
+            "range": {
+                "start": {
+                    "line": 71,
+                    "character": 17
+                },
+                "end": {
+                    "line": 71,
+                    "character": 21
+                }
+            },
+            "rule": "reportAttributeAccessIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "\"init\" is not a known attribute of \"None\"",
+            "range": {
+                "start": {
+                    "line": 71,
+                    "character": 17
+                },
+                "end": {
+                    "line": 71,
+                    "character": 21
+                }
+            },
+            "rule": "reportOptionalMemberAccess"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"list_indexes\" is unknown",
+            "range": {
+                "start": {
+                    "line": 82,
+                    "character": 25
+                },
+                "end": {
+                    "line": 82,
+                    "character": 46
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "\"list_indexes\" is not a known attribute of module \"pinecone\"",
+            "range": {
+                "start": {
+                    "line": 82,
+                    "character": 34
+                },
+                "end": {
+                    "line": 82,
+                    "character": 46
+                }
+            },
+            "rule": "reportAttributeAccessIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "\"list_indexes\" is not a known attribute of \"None\"",
+            "range": {
+                "start": {
+                    "line": 82,
+                    "character": 34
+                },
+                "end": {
+                    "line": 82,
+                    "character": 46
+                }
+            },
+            "rule": "reportOptionalMemberAccess"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"_with_retries\" is partially unknown\n  Type of \"_with_retries\" is \"(func: (...) -> Unknown, ...) -> (Unknown | None)\"",
+            "range": {
+                "start": {
+                    "line": 84,
+                    "character": 8
+                },
+                "end": {
+                    "line": 84,
+                    "character": 26
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"create_index\" is unknown",
+            "range": {
+                "start": {
+                    "line": 85,
+                    "character": 12
+                },
+                "end": {
+                    "line": 85,
+                    "character": 33
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"func\" in function \"_with_retries\"",
+            "range": {
+                "start": {
+                    "line": 85,
+                    "character": 12
+                },
+                "end": {
+                    "line": 85,
+                    "character": 33
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "\"create_index\" is not a known attribute of module \"pinecone\"",
+            "range": {
+                "start": {
+                    "line": 85,
+                    "character": 21
+                },
+                "end": {
+                    "line": 85,
+                    "character": 33
+                }
+            },
+            "rule": "reportAttributeAccessIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "\"create_index\" is not a known attribute of \"None\"",
+            "range": {
+                "start": {
+                    "line": 85,
+                    "character": 21
+                },
+                "end": {
+                    "line": 85,
+                    "character": 33
+                }
+            },
+            "rule": "reportOptionalMemberAccess"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"list_indexes\" is unknown",
+            "range": {
+                "start": {
+                    "line": 95,
+                    "character": 29
+                },
+                "end": {
+                    "line": 95,
+                    "character": 50
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "\"list_indexes\" is not a known attribute of module \"pinecone\"",
+            "range": {
+                "start": {
+                    "line": 95,
+                    "character": 38
+                },
+                "end": {
+                    "line": 95,
+                    "character": 50
+                }
+            },
+            "rule": "reportAttributeAccessIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "\"list_indexes\" is not a known attribute of \"None\"",
+            "range": {
+                "start": {
+                    "line": 95,
+                    "character": 38
+                },
+                "end": {
+                    "line": 95,
+                    "character": 50
+                }
+            },
+            "rule": "reportOptionalMemberAccess"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"_with_retries\" is partially unknown\n  Type of \"_with_retries\" is \"(func: (...) -> Unknown, ...) -> (Unknown | None)\"",
+            "range": {
+                "start": {
+                    "line": 97,
+                    "character": 8
+                },
+                "end": {
+                    "line": 97,
+                    "character": 26
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"delete_index\" is unknown",
+            "range": {
+                "start": {
+                    "line": 97,
+                    "character": 27
+                },
+                "end": {
+                    "line": 97,
+                    "character": 48
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"func\" in function \"_with_retries\"",
+            "range": {
+                "start": {
+                    "line": 97,
+                    "character": 27
+                },
+                "end": {
+                    "line": 97,
+                    "character": 48
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "\"delete_index\" is not a known attribute of module \"pinecone\"",
+            "range": {
+                "start": {
+                    "line": 97,
+                    "character": 36
+                },
+                "end": {
+                    "line": 97,
+                    "character": 48
+                }
+            },
+            "rule": "reportAttributeAccessIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "\"delete_index\" is not a known attribute of \"None\"",
+            "range": {
+                "start": {
+                    "line": 97,
+                    "character": 36
+                },
+                "end": {
+                    "line": 97,
+                    "character": 48
+                }
+            },
+            "rule": "reportOptionalMemberAccess"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Return type is unknown",
+            "range": {
+                "start": {
+                    "line": 99,
+                    "character": 8
+                },
+                "end": {
+                    "line": 99,
+                    "character": 17
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"Index\" is unknown",
+            "range": {
+                "start": {
+                    "line": 100,
+                    "character": 15
+                },
+                "end": {
+                    "line": 100,
+                    "character": 29
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Return type is unknown",
+            "range": {
+                "start": {
+                    "line": 100,
+                    "character": 15
+                },
+                "end": {
+                    "line": 100,
+                    "character": 41
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "\"Index\" is not a known attribute of module \"pinecone\"",
+            "range": {
+                "start": {
+                    "line": 100,
+                    "character": 24
+                },
+                "end": {
+                    "line": 100,
+                    "character": 29
+                }
+            },
+            "rule": "reportAttributeAccessIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "\"Index\" is not a known attribute of \"None\"",
+            "range": {
+                "start": {
+                    "line": 100,
+                    "character": 24
+                },
+                "end": {
+                    "line": 100,
+                    "character": 29
+                }
+            },
+            "rule": "reportOptionalMemberAccess"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"description\" is unknown",
+            "range": {
+                "start": {
+                    "line": 104,
+                    "character": 12
+                },
+                "end": {
+                    "line": 104,
+                    "character": 23
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"describe_index\" is unknown",
+            "range": {
+                "start": {
+                    "line": 104,
+                    "character": 26
+                },
+                "end": {
+                    "line": 104,
+                    "character": 49
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "\"describe_index\" is not a known attribute of module \"pinecone\"",
+            "range": {
+                "start": {
+                    "line": 104,
+                    "character": 35
+                },
+                "end": {
+                    "line": 104,
+                    "character": 49
+                }
+            },
+            "rule": "reportAttributeAccessIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "\"describe_index\" is not a known attribute of \"None\"",
+            "range": {
+                "start": {
+                    "line": 104,
+                    "character": 35
+                },
+                "end": {
+                    "line": 104,
+                    "character": 49
+                }
+            },
+            "rule": "reportOptionalMemberAccess"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"actual_dim\" is unknown",
+            "range": {
+                "start": {
+                    "line": 105,
+                    "character": 12
+                },
+                "end": {
+                    "line": 105,
+                    "character": 22
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"dimension\" is unknown",
+            "range": {
+                "start": {
+                    "line": 105,
+                    "character": 25
+                },
+                "end": {
+                    "line": 105,
+                    "character": 46
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"args\" in function \"error\"",
+            "range": {
+                "start": {
+                    "line": 110,
+                    "character": 20
+                },
+                "end": {
+                    "line": 110,
+                    "character": 30
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"index\" is unknown",
+            "range": {
+                "start": {
+                    "line": 130,
+                    "character": 8
+                },
+                "end": {
+                    "line": 130,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"_with_retries\" is partially unknown\n  Type of \"_with_retries\" is \"(func: (...) -> Unknown, ...) -> (Unknown | None)\"",
+            "range": {
+                "start": {
+                    "line": 137,
+                    "character": 12
+                },
+                "end": {
+                    "line": 137,
+                    "character": 30
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"upsert\" is unknown",
+            "range": {
+                "start": {
+                    "line": 138,
+                    "character": 16
+                },
+                "end": {
+                    "line": 138,
+                    "character": 28
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"func\" in function \"_with_retries\"",
+            "range": {
+                "start": {
+                    "line": 138,
+                    "character": 16
+                },
+                "end": {
+                    "line": 138,
+                    "character": 28
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"index\" is unknown",
+            "range": {
+                "start": {
+                    "line": 153,
+                    "character": 8
+                },
+                "end": {
+                    "line": 153,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"_with_retries\" is partially unknown\n  Type of \"_with_retries\" is \"(func: (...) -> Unknown, ...) -> (Unknown | None)\"",
+            "range": {
+                "start": {
+                    "line": 154,
+                    "character": 15
+                },
+                "end": {
+                    "line": 154,
+                    "character": 33
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Return type, \"Unknown | None\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 154,
+                    "character": 15
+                },
+                "end": {
+                    "line": 159,
+                    "character": 9
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"query\" is unknown",
+            "range": {
+                "start": {
+                    "line": 155,
+                    "character": 12
+                },
+                "end": {
+                    "line": 155,
+                    "character": 23
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/integrations/pinecone_client.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"func\" in function \"_with_retries\"",
+            "range": {
+                "start": {
+                    "line": 155,
+                    "character": 12
+                },
+                "end": {
+                    "line": 155,
+                    "character": 23
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/auto_tuner.py",
+            "severity": "error",
+            "message": "Type of \"locks\" is partially unknown\n  Type of \"locks\" is \"set[Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 36,
+                    "character": 8
+                },
+                "end": {
+                    "line": 36,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/performance.py",
+            "severity": "error",
+            "message": "Type of parameter \"exc_type\" is unknown",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 23
+                },
+                "end": {
+                    "line": 30,
+                    "character": 31
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/performance.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"exc_type\"",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 23
+                },
+                "end": {
+                    "line": 30,
+                    "character": 31
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/performance.py",
+            "severity": "error",
+            "message": "Type of parameter \"exc\" is unknown",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 33
+                },
+                "end": {
+                    "line": 30,
+                    "character": 36
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/performance.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"exc\"",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 33
+                },
+                "end": {
+                    "line": 30,
+                    "character": 36
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/performance.py",
+            "severity": "error",
+            "message": "Type of parameter \"tb\" is unknown",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 38
+                },
+                "end": {
+                    "line": 30,
+                    "character": 40
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/performance.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"tb\"",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 38
+                },
+                "end": {
+                    "line": 30,
+                    "character": 40
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/performance.py",
+            "severity": "error",
+            "message": "Type of parameter \"exc_type\" is unknown",
+            "range": {
+                "start": {
+                    "line": 74,
+                    "character": 23
+                },
+                "end": {
+                    "line": 74,
+                    "character": 31
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/performance.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"exc_type\"",
+            "range": {
+                "start": {
+                    "line": 74,
+                    "character": 23
+                },
+                "end": {
+                    "line": 74,
+                    "character": 31
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/performance.py",
+            "severity": "error",
+            "message": "Type of parameter \"exc\" is unknown",
+            "range": {
+                "start": {
+                    "line": 74,
+                    "character": 33
+                },
+                "end": {
+                    "line": 74,
+                    "character": 36
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/performance.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"exc\"",
+            "range": {
+                "start": {
+                    "line": 74,
+                    "character": 33
+                },
+                "end": {
+                    "line": 74,
+                    "character": 36
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/performance.py",
+            "severity": "error",
+            "message": "Type of parameter \"tb\" is unknown",
+            "range": {
+                "start": {
+                    "line": 74,
+                    "character": 38
+                },
+                "end": {
+                    "line": 74,
+                    "character": 40
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/performance.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"tb\"",
+            "range": {
+                "start": {
+                    "line": 74,
+                    "character": 38
+                },
+                "end": {
+                    "line": 74,
+                    "character": 40
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/performance.py",
+            "severity": "error",
+            "message": "Type of \"__exit__\" is partially unknown\n  Type of \"__exit__\" is \"(exc_type: Unknown, exc: Unknown, tb: Unknown) -> None\"",
+            "range": {
+                "start": {
+                    "line": 78,
+                    "character": 12
+                },
+                "end": {
+                    "line": 78,
+                    "character": 30
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/performance.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"exc_type\" in function \"__exit__\"",
+            "range": {
+                "start": {
+                    "line": 78,
+                    "character": 31
+                },
+                "end": {
+                    "line": 78,
+                    "character": 39
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/performance.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"exc\" in function \"__exit__\"",
+            "range": {
+                "start": {
+                    "line": 78,
+                    "character": 41
+                },
+                "end": {
+                    "line": 78,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/monitoring/performance.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"tb\" in function \"__exit__\"",
+            "range": {
+                "start": {
+                    "line": 78,
+                    "character": 46
+                },
+                "end": {
+                    "line": 78,
+                    "character": 48
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/query_service.py",
+            "severity": "error",
+            "message": "Argument of type \"Any | int\" cannot be assigned to parameter \"enable_rerank\" of type \"bool\" in function \"query\"\n  Type \"Any | int\" is not assignable to type \"bool\"\n    \"int\" is not assignable to \"bool\"",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 30
+                },
+                "end": {
+                    "line": 46,
+                    "character": 53
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Import \"openvino.runtime\" could not be resolved",
+            "range": {
+                "start": {
+                    "line": 35,
+                    "character": 21
+                },
+                "end": {
+                    "line": 35,
+                    "character": 37
+                }
+            },
+            "rule": "reportMissingImports"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"Core\" is unknown",
+            "range": {
+                "start": {
+                    "line": 35,
+                    "character": 45
+                },
+                "end": {
+                    "line": 35,
+                    "character": 49
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"core\" is unknown",
+            "range": {
+                "start": {
+                    "line": 37,
+                    "character": 16
+                },
+                "end": {
+                    "line": 37,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"tokenizer\" is unknown",
+            "range": {
+                "start": {
+                    "line": 42,
+                    "character": 12
+                },
+                "end": {
+                    "line": 42,
+                    "character": 26
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"from_pretrained\" is partially unknown\n  Type of \"from_pretrained\" is \"(pretrained_model_name_or_path: Unknown, ...) -> Unknown\"",
+            "range": {
+                "start": {
+                    "line": 42,
+                    "character": 29
+                },
+                "end": {
+                    "line": 42,
+                    "character": 58
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"model\" is unknown",
+            "range": {
+                "start": {
+                    "line": 48,
+                    "character": 16
+                },
+                "end": {
+                    "line": 48,
+                    "character": 26
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"core\" is unknown",
+            "range": {
+                "start": {
+                    "line": 48,
+                    "character": 29
+                },
+                "end": {
+                    "line": 48,
+                    "character": 38
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"compile_model\" is unknown",
+            "range": {
+                "start": {
+                    "line": 48,
+                    "character": 29
+                },
+                "end": {
+                    "line": 48,
+                    "character": 52
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"model\" is partially unknown\n  Type of \"model\" is \"Unknown | Any\"",
+            "range": {
+                "start": {
+                    "line": 55,
+                    "character": 16
+                },
+                "end": {
+                    "line": 55,
+                    "character": 26
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"from_pretrained\" is partially unknown\n  Type of \"from_pretrained\" is \"(pretrained_model_name_or_path: str | PathLike[str], ...) -> (Unknown | Any)\"",
+            "range": {
+                "start": {
+                    "line": 56,
+                    "character": 20
+                },
+                "end": {
+                    "line": 56,
+                    "character": 70
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"model\" is partially unknown\n  Type of \"model\" is \"Unknown | Any\"",
+            "range": {
+                "start": {
+                    "line": 61,
+                    "character": 16
+                },
+                "end": {
+                    "line": 61,
+                    "character": 26
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"to\" is partially unknown\n  Type of \"to\" is \"Unknown | Any\"",
+            "range": {
+                "start": {
+                    "line": 61,
+                    "character": 16
+                },
+                "end": {
+                    "line": 61,
+                    "character": 29
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"model\" is partially unknown\n  Type of \"model\" is \"Unknown | Any\"",
+            "range": {
+                "start": {
+                    "line": 69,
+                    "character": 20
+                },
+                "end": {
+                    "line": 69,
+                    "character": 30
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"to\" is partially unknown\n  Type of \"to\" is \"Unknown | Any\"",
+            "range": {
+                "start": {
+                    "line": 69,
+                    "character": 20
+                },
+                "end": {
+                    "line": 69,
+                    "character": 33
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"inputs\" is unknown",
+            "range": {
+                "start": {
+                    "line": 77,
+                    "character": 12
+                },
+                "end": {
+                    "line": 77,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"tokenizer\" is partially unknown\n  Type of \"tokenizer\" is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 77,
+                    "character": 21
+                },
+                "end": {
+                    "line": 77,
+                    "character": 35
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Object of type \"None\" cannot be called",
+            "range": {
+                "start": {
+                    "line": 77,
+                    "character": 21
+                },
+                "end": {
+                    "line": 83,
+                    "character": 13
+                }
+            },
+            "rule": "reportOptionalCall"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"result\" is partially unknown\n  Type of \"result\" is \"Any | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 84,
+                    "character": 12
+                },
+                "end": {
+                    "line": 84,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"model\" is partially unknown\n  Type of \"model\" is \"Unknown | Any | None\"",
+            "range": {
+                "start": {
+                    "line": 84,
+                    "character": 21
+                },
+                "end": {
+                    "line": 84,
+                    "character": 31
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Object of type \"None\" cannot be called",
+            "range": {
+                "start": {
+                    "line": 84,
+                    "character": 21
+                },
+                "end": {
+                    "line": 84,
+                    "character": 39
+                }
+            },
+            "rule": "reportOptionalCall"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"logits\" is partially unknown\n  Type of \"logits\" is \"Any | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 85,
+                    "character": 12
+                },
+                "end": {
+                    "line": 85,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"squeeze\" is partially unknown\n  Type of \"squeeze\" is \"Any | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 85,
+                    "character": 21
+                },
+                "end": {
+                    "line": 85,
+                    "character": 56
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"i\" in function \"next\"\n  Argument type is \"SupportsNext[Any | Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 85,
+                    "character": 26
+                },
+                "end": {
+                    "line": 85,
+                    "character": 47
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"values\" is partially unknown\n  Type of \"values\" is \"Any | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 85,
+                    "character": 31
+                },
+                "end": {
+                    "line": 85,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"object\" in function \"iter\"\n  Argument type is \"Any | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 85,
+                    "character": 31
+                },
+                "end": {
+                    "line": 85,
+                    "character": 46
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"tolist\" is partially unknown\n  Type of \"tolist\" is \"Any | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 86,
+                    "character": 19
+                },
+                "end": {
+                    "line": 86,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Return type, \"Any | Unknown\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 86,
+                    "character": 19
+                },
+                "end": {
+                    "line": 86,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"inputs\" is unknown",
+            "range": {
+                "start": {
+                    "line": 87,
+                    "character": 8
+                },
+                "end": {
+                    "line": 87,
+                    "character": 14
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"tokenizer\" is partially unknown\n  Type of \"tokenizer\" is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 87,
+                    "character": 17
+                },
+                "end": {
+                    "line": 87,
+                    "character": 31
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Object of type \"None\" cannot be called",
+            "range": {
+                "start": {
+                    "line": 87,
+                    "character": 17
+                },
+                "end": {
+                    "line": 93,
+                    "character": 9
+                }
+            },
+            "rule": "reportOptionalCall"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"inputs\" is partially unknown\n  Type of \"inputs\" is \"dict[Unknown, Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 95,
+                    "character": 12
+                },
+                "end": {
+                    "line": 95,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"to\" is unknown",
+            "range": {
+                "start": {
+                    "line": 95,
+                    "character": 25
+                },
+                "end": {
+                    "line": 95,
+                    "character": 29
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"k\" is unknown",
+            "range": {
+                "start": {
+                    "line": 95,
+                    "character": 41
+                },
+                "end": {
+                    "line": 95,
+                    "character": 42
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"v\" is unknown",
+            "range": {
+                "start": {
+                    "line": 95,
+                    "character": 44
+                },
+                "end": {
+                    "line": 95,
+                    "character": 45
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"items\" is unknown",
+            "range": {
+                "start": {
+                    "line": 95,
+                    "character": 49
+                },
+                "end": {
+                    "line": 95,
+                    "character": 61
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"logits\" is partially unknown\n  Type of \"logits\" is \"Any | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 97,
+                    "character": 12
+                },
+                "end": {
+                    "line": 97,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"model\" is partially unknown\n  Type of \"model\" is \"Unknown | Any | None\"",
+            "range": {
+                "start": {
+                    "line": 97,
+                    "character": 21
+                },
+                "end": {
+                    "line": 97,
+                    "character": 31
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Object of type \"None\" cannot be called",
+            "range": {
+                "start": {
+                    "line": 97,
+                    "character": 21
+                },
+                "end": {
+                    "line": 97,
+                    "character": 41
+                }
+            },
+            "rule": "reportOptionalCall"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"logits\" is partially unknown\n  Type of \"logits\" is \"Any | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 97,
+                    "character": 21
+                },
+                "end": {
+                    "line": 97,
+                    "character": 48
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"squeeze\" is partially unknown\n  Type of \"squeeze\" is \"Any | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 97,
+                    "character": 21
+                },
+                "end": {
+                    "line": 97,
+                    "character": 56
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"cpu\" is partially unknown\n  Type of \"cpu\" is \"Any | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 98,
+                    "character": 15
+                },
+                "end": {
+                    "line": 98,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Type of \"tolist\" is partially unknown\n  Type of \"tolist\" is \"Any | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 98,
+                    "character": 15
+                },
+                "end": {
+                    "line": 98,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ranking/reranker.py",
+            "severity": "error",
+            "message": "Return type, \"Any | Unknown\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 98,
+                    "character": 15
+                },
+                "end": {
+                    "line": 98,
+                    "character": 36
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/dense.py",
+            "severity": "error",
+            "message": "Type of \"core\" is unknown",
+            "range": {
+                "start": {
+                    "line": 57,
+                    "character": 28
+                },
+                "end": {
+                    "line": 57,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/dense.py",
+            "severity": "error",
+            "message": "Type of \"compile_model\" is unknown",
+            "range": {
+                "start": {
+                    "line": 58,
+                    "character": 45
+                },
+                "end": {
+                    "line": 58,
+                    "character": 63
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/dense.py",
+            "severity": "error",
+            "message": "Type of \"encode\" is partially unknown\n  Type of \"encode\" is \"Overload[(sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[False] = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[True] = ..., convert_to_tensor: Literal[False] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> ndarray[tuple[Any, ...], dtype[Any]], (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: Literal[True] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[Tensor], (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[dict[str, Tensor]], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> dict[str, Tensor], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor]\"",
+            "range": {
+                "start": {
+                    "line": 77,
+                    "character": 20
+                },
+                "end": {
+                    "line": 77,
+                    "character": 38
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/dense.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"func\" in function \"to_thread\"\n  Argument type is \"Overload[(sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[False] = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[True] = ..., convert_to_tensor: Literal[False] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> ndarray[tuple[Any, ...], dtype[Any]], (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: Literal[True] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[Tensor], (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[dict[str, Tensor]], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> dict[str, Tensor], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor]\"",
+            "range": {
+                "start": {
+                    "line": 77,
+                    "character": 20
+                },
+                "end": {
+                    "line": 77,
+                    "character": 38
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/dense.py",
+            "severity": "error",
+            "message": "Type of \"encode\" is partially unknown\n  Type of \"encode\" is \"Overload[(sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[False] = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[True] = ..., convert_to_tensor: Literal[False] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> ndarray[tuple[Any, ...], dtype[Any]], (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: Literal[True] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[Tensor], (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[dict[str, Tensor]], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> dict[str, Tensor], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor]\"",
+            "range": {
+                "start": {
+                    "line": 84,
+                    "character": 16
+                },
+                "end": {
+                    "line": 84,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/dense.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"func\" in function \"to_thread\"\n  Argument type is \"Overload[(sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[False] = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[True] = ..., convert_to_tensor: Literal[False] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> ndarray[tuple[Any, ...], dtype[Any]], (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: Literal[True] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[Tensor], (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[dict[str, Tensor]], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> dict[str, Tensor], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor]\"",
+            "range": {
+                "start": {
+                    "line": 84,
+                    "character": 16
+                },
+                "end": {
+                    "line": 84,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/dense.py",
+            "severity": "error",
+            "message": "Type of \"tolist\" is partially unknown\n  Type of \"tolist\" is \"Unknown | Overload[() -> Any, () -> Any, () -> list[Any], () -> list[list[Any]], () -> list[list[list[Any]]], () -> Any]\"",
+            "range": {
+                "start": {
+                    "line": 89,
+                    "character": 15
+                },
+                "end": {
+                    "line": 89,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/dense.py",
+            "severity": "error",
+            "message": "Return type, \"Any | Unknown\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 89,
+                    "character": 15
+                },
+                "end": {
+                    "line": 89,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/dense.py",
+            "severity": "error",
+            "message": "Cannot access attribute \"tolist\" for class \"object\"\n  Attribute \"tolist\" is unknown",
+            "range": {
+                "start": {
+                    "line": 89,
+                    "character": 26
+                },
+                "end": {
+                    "line": 89,
+                    "character": 32
+                }
+            },
+            "rule": "reportAttributeAccessIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/dense.py",
+            "severity": "error",
+            "message": "Type of \"encode\" is partially unknown\n  Type of \"encode\" is \"Overload[(sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[False] = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[True] = ..., convert_to_tensor: Literal[False] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> ndarray[tuple[Any, ...], dtype[Any]], (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: Literal[True] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[Tensor], (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[dict[str, Tensor]], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> dict[str, Tensor], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor]\"",
+            "range": {
+                "start": {
+                    "line": 132,
+                    "character": 56
+                },
+                "end": {
+                    "line": 132,
+                    "character": 74
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/dense.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"func\" in function \"to_thread\"\n  Argument type is \"Overload[(sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[False] = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[True] = ..., convert_to_tensor: Literal[False] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> ndarray[tuple[Any, ...], dtype[Any]], (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: Literal[True] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[Tensor], (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[dict[str, Tensor]], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> dict[str, Tensor], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor]\"",
+            "range": {
+                "start": {
+                    "line": 132,
+                    "character": 56
+                },
+                "end": {
+                    "line": 132,
+                    "character": 74
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/dense.py",
+            "severity": "error",
+            "message": "Type of \"encode\" is partially unknown\n  Type of \"encode\" is \"Overload[(sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[False] = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[True] = ..., convert_to_tensor: Literal[False] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> ndarray[tuple[Any, ...], dtype[Any]], (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: Literal[True] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[Tensor], (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[dict[str, Tensor]], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> dict[str, Tensor], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor]\"",
+            "range": {
+                "start": {
+                    "line": 134,
+                    "character": 52
+                },
+                "end": {
+                    "line": 134,
+                    "character": 70
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/dense.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"func\" in function \"to_thread\"\n  Argument type is \"Overload[(sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[False] = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[True] = ..., convert_to_tensor: Literal[False] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> ndarray[tuple[Any, ...], dtype[Any]], (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: Literal[True] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[Tensor], (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[dict[str, Tensor]], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> dict[str, Tensor], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor]\"",
+            "range": {
+                "start": {
+                    "line": 134,
+                    "character": 52
+                },
+                "end": {
+                    "line": 134,
+                    "character": 70
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/dense.py",
+            "severity": "error",
+            "message": "Type of \"tolist\" is partially unknown\n  Type of \"tolist\" is \"Unknown | (() -> list[Unknown])\"",
+            "range": {
+                "start": {
+                    "line": 135,
+                    "character": 19
+                },
+                "end": {
+                    "line": 135,
+                    "character": 35
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/dense.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[Unknown] | Unknown, dict[str, Any]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 135,
+                    "character": 19
+                },
+                "end": {
+                    "line": 135,
+                    "character": 83
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/dense.py",
+            "severity": "error",
+            "message": "Cannot access attribute \"tolist\" for class \"object\"\n  Attribute \"tolist\" is unknown",
+            "range": {
+                "start": {
+                    "line": 135,
+                    "character": 29
+                },
+                "end": {
+                    "line": 135,
+                    "character": 35
+                }
+            },
+            "rule": "reportAttributeAccessIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/hybrid.py",
+            "severity": "error",
+            "message": "Type of \"results\" is unknown",
+            "range": {
+                "start": {
+                    "line": 43,
+                    "character": 12
+                },
+                "end": {
+                    "line": 43,
+                    "character": 19
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/hybrid.py",
+            "severity": "error",
+            "message": "Type of \"meta\" is unknown",
+            "range": {
+                "start": {
+                    "line": 43,
+                    "character": 21
+                },
+                "end": {
+                    "line": 43,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/hybrid.py",
+            "severity": "error",
+            "message": "\"CoroutineType[Any, Any, Tuple[List[Tuple[str, float]], Dict[str, Any]]]\" is not iterable\n  \"__iter__\" method not defined",
+            "range": {
+                "start": {
+                    "line": 43,
+                    "character": 28
+                },
+                "end": {
+                    "line": 43,
+                    "character": 64
+                }
+            },
+            "rule": "reportGeneralTypeIssues"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/hybrid.py",
+            "severity": "error",
+            "message": "Type of \"wrapped\" is partially unknown\n  Type of \"wrapped\" is \"list[dict[str, Unknown | str]]\"",
+            "range": {
+                "start": {
+                    "line": 44,
+                    "character": 12
+                },
+                "end": {
+                    "line": 44,
+                    "character": 19
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/hybrid.py",
+            "severity": "error",
+            "message": "Type of \"doc_id\" is unknown",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 20
+                },
+                "end": {
+                    "line": 46,
+                    "character": 26
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/hybrid.py",
+            "severity": "error",
+            "message": "Type of \"score\" is unknown",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 28
+                },
+                "end": {
+                    "line": 46,
+                    "character": 33
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/hybrid.py",
+            "severity": "error",
+            "message": "Type of \"update\" is unknown",
+            "range": {
+                "start": {
+                    "line": 48,
+                    "character": 12
+                },
+                "end": {
+                    "line": 48,
+                    "character": 23
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/hybrid.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[dict[str, Unknown | str]], Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 49,
+                    "character": 19
+                },
+                "end": {
+                    "line": 49,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/hybrid.py",
+            "severity": "error",
+            "message": "Type of \"dense_results\" is unknown",
+            "range": {
+                "start": {
+                    "line": 67,
+                    "character": 12
+                },
+                "end": {
+                    "line": 67,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/hybrid.py",
+            "severity": "error",
+            "message": "Type of \"_\" is unknown",
+            "range": {
+                "start": {
+                    "line": 67,
+                    "character": 27
+                },
+                "end": {
+                    "line": 67,
+                    "character": 28
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/hybrid.py",
+            "severity": "error",
+            "message": "\"CoroutineType[Any, Any, Tuple[List[Tuple[str, float]], Dict[str, Any]]]\" is not iterable\n  \"__iter__\" method not defined",
+            "range": {
+                "start": {
+                    "line": 67,
+                    "character": 31
+                },
+                "end": {
+                    "line": 67,
+                    "character": 52
+                }
+            },
+            "rule": "reportGeneralTypeIssues"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/lexical.py",
+            "severity": "error",
+            "message": "Stub file not found for \"rank_bm25\"",
+            "range": {
+                "start": {
+                    "line": 4,
+                    "character": 5
+                },
+                "end": {
+                    "line": 4,
+                    "character": 14
+                }
+            },
+            "rule": "reportMissingTypeStubs"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/lexical.py",
+            "severity": "error",
+            "message": "Stub file not found for \"nltk.stem\"",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 9
+                },
+                "end": {
+                    "line": 7,
+                    "character": 18
+                }
+            },
+            "rule": "reportMissingTypeStubs"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/lexical.py",
+            "severity": "error",
+            "message": "Object of type \"None\" cannot be called",
+            "range": {
+                "start": {
+                    "line": 31,
+                    "character": 23
+                },
+                "end": {
+                    "line": 31,
+                    "character": 38
+                }
+            },
+            "rule": "reportOptionalCall"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/lexical.py",
+            "severity": "error",
+            "message": "Type of \"tokens\" is partially unknown\n  Type of \"tokens\" is \"list[Unknown | str]\"",
+            "range": {
+                "start": {
+                    "line": 45,
+                    "character": 12
+                },
+                "end": {
+                    "line": 45,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/lexical.py",
+            "severity": "error",
+            "message": "Type of \"stem\" is partially unknown\n  Type of \"stem\" is \"(word: Unknown, to_lowercase: bool = True) -> Unknown\"",
+            "range": {
+                "start": {
+                    "line": 45,
+                    "character": 22
+                },
+                "end": {
+                    "line": 45,
+                    "character": 39
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/lexical.py",
+            "severity": "error",
+            "message": "Return type, \"list[Unknown | str] | List[str]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 15
+                },
+                "end": {
+                    "line": 46,
+                    "character": 21
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/lexical.py",
+            "severity": "error",
+            "message": "Type of \"append\" is partially unknown\n  Type of \"append\" is \"(object: Unknown, /) -> None\"",
+            "range": {
+                "start": {
+                    "line": 61,
+                    "character": 16
+                },
+                "end": {
+                    "line": 61,
+                    "character": 26
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/lexical.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[Unknown], dict[str, Any]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 64,
+                    "character": 19
+                },
+                "end": {
+                    "line": 64,
+                    "character": 64
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/lexical.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"obj\" in function \"len\"\n  Argument type is \"list[Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 64,
+                    "character": 59
+                },
+                "end": {
+                    "line": 64,
+                    "character": 62
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/lexical.py",
+            "severity": "error",
+            "message": "Type of \"scores\" is partially unknown\n  Type of \"scores\" is \"ndarray[tuple[int], dtype[float64]] | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 77,
+                    "character": 12
+                },
+                "end": {
+                    "line": 77,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/lexical.py",
+            "severity": "error",
+            "message": "Type of \"get_scores\" is partially unknown\n  Type of \"get_scores\" is \"(query: Unknown) -> (ndarray[tuple[int], dtype[float64]] | Unknown)\"",
+            "range": {
+                "start": {
+                    "line": 77,
+                    "character": 21
+                },
+                "end": {
+                    "line": 77,
+                    "character": 41
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/lexical.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"iter2\" in function \"__new__\"\n  Argument type is \"ndarray[tuple[int], dtype[float64]] | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 79,
+                    "character": 34
+                },
+                "end": {
+                    "line": 79,
+                    "character": 40
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/retrieval/lexical.py",
+            "severity": "error",
+            "message": "Type \"tuple[list[tuple[str, float64]], dict[str, Any]]\" is not assignable to return type \"Tuple[List[Tuple[str, float]], Dict[str, Any]]\"\n  \"list[tuple[str, float64]]\" is not assignable to \"List[Tuple[str, float]]\"\n    Type parameter \"_T@list\" is invariant, but \"tuple[str, float64]\" is not the same as \"Tuple[str, float]\"\n    Consider switching from \"list\" to \"Sequence\" which is covariant",
+            "range": {
+                "start": {
+                    "line": 81,
+                    "character": 19
+                },
+                "end": {
+                    "line": 81,
+                    "character": 25
+                }
+            },
+            "rule": "reportReturnType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/services/document_service.py",
+            "severity": "error",
+            "message": "Argument of type \"Path\" cannot be assigned to parameter \"docx\" of type \"str | IO[bytes] | None\" in function \"Document\"\n  Type \"Path\" is not assignable to type \"str | IO[bytes] | None\"\n    \"Path\" is not assignable to \"str\"\n    \"Path\" is not assignable to \"IO[bytes]\"\n    \"Path\" is not assignable to \"None\"",
+            "range": {
+                "start": {
+                    "line": 51,
+                    "character": 31
+                },
+                "end": {
+                    "line": 51,
+                    "character": 35
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/services/document_service.py",
+            "severity": "error",
+            "message": "Type of \"dense_ids\" is unknown",
+            "range": {
+                "start": {
+                    "line": 132,
+                    "character": 12
+                },
+                "end": {
+                    "line": 132,
+                    "character": 21
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/services/document_service.py",
+            "severity": "error",
+            "message": "Type of \"dense_meta\" is unknown",
+            "range": {
+                "start": {
+                    "line": 132,
+                    "character": 23
+                },
+                "end": {
+                    "line": 132,
+                    "character": 33
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/services/document_service.py",
+            "severity": "error",
+            "message": "\"CoroutineType[Any, Any, Tuple[List[str], Dict[str, Any]]]\" is not iterable\n  \"__iter__\" method not defined",
+            "range": {
+                "start": {
+                    "line": 132,
+                    "character": 36
+                },
+                "end": {
+                    "line": 134,
+                    "character": 13
+                }
+            },
+            "rule": "reportGeneralTypeIssues"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/chat.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[Unknown], dict[str, str | dict[Unknown, Unknown]]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 23,
+                    "character": 8
+                },
+                "end": {
+                    "line": 23,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/chat.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[Unknown], dict[str, str | dict[Unknown, Unknown]]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 24,
+                    "character": 15
+                },
+                "end": {
+                    "line": 28,
+                    "character": 9
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/chat.py",
+            "severity": "error",
+            "message": "Argument of type \"_StubHybridRetriever\" cannot be assigned to parameter \"retriever\" of type \"HybridRetriever\" in function \"__init__\"\n  \"_StubHybridRetriever\" is not assignable to \"HybridRetriever\"",
+            "range": {
+                "start": {
+                    "line": 31,
+                    "character": 29
+                },
+                "end": {
+                    "line": 31,
+                    "character": 51
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/chat.py",
+            "severity": "error",
+            "message": "Type of \"append\" is partially unknown\n  Type of \"append\" is \"(object: Unknown, /) -> None\"",
+            "range": {
+                "start": {
+                    "line": 73,
+                    "character": 8
+                },
+                "end": {
+                    "line": 73,
+                    "character": 24
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/chat.py",
+            "severity": "error",
+            "message": "Type of \"metadata\" is partially unknown\n  Type of \"metadata\" is \"dict[str, Any | dict[str, Any | None] | list[Unknown]]\"",
+            "range": {
+                "start": {
+                    "line": 81,
+                    "character": 4
+                },
+                "end": {
+                    "line": 81,
+                    "character": 12
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/components/__init__.py",
+            "severity": "error",
+            "message": "\"ranking_controls\" is specified in __all__ but is not present in module",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 11
+                },
+                "end": {
+                    "line": 2,
+                    "character": 29
+                }
+            },
+            "rule": "reportUnsupportedDunderAll"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/components/__init__.py",
+            "severity": "error",
+            "message": "\"transparency\" is specified in __all__ but is not present in module",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 31
+                },
+                "end": {
+                    "line": 2,
+                    "character": 45
+                }
+            },
+            "rule": "reportUnsupportedDunderAll"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/components/transparency.py",
+            "severity": "error",
+            "message": "Type of \"append\" is partially unknown\n  Type of \"append\" is \"(object: Unknown, /) -> None\"",
+            "range": {
+                "start": {
+                    "line": 28,
+                    "character": 12
+                },
+                "end": {
+                    "line": 28,
+                    "character": 24
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/components/transparency.py",
+            "severity": "error",
+            "message": "Type of \"append\" is partially unknown\n  Type of \"append\" is \"(object: Unknown, /) -> None\"",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 12
+                },
+                "end": {
+                    "line": 30,
+                    "character": 24
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/components/transparency.py",
+            "severity": "error",
+            "message": "Type of \"append\" is partially unknown\n  Type of \"append\" is \"(object: Unknown, /) -> None\"",
+            "range": {
+                "start": {
+                    "line": 32,
+                    "character": 12
+                },
+                "end": {
+                    "line": 32,
+                    "character": 24
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/components/transparency.py",
+            "severity": "error",
+            "message": "Type of \"append\" is partially unknown\n  Type of \"append\" is \"(object: Unknown, /) -> None\"",
+            "range": {
+                "start": {
+                    "line": 34,
+                    "character": 12
+                },
+                "end": {
+                    "line": 34,
+                    "character": 24
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/components/transparency.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"iterable\" in function \"join\"\n  Argument type is \"list[Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 35,
+                    "character": 33
+                },
+                "end": {
+                    "line": 35,
+                    "character": 38
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/components/transparency.py",
+            "severity": "error",
+            "message": "Type of \"content\" is partially unknown\n  Type of \"content\" is \"dict[Unknown, Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 57,
+                    "character": 4
+                },
+                "end": {
+                    "line": 57,
+                    "character": 11
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/components/transparency.py",
+            "severity": "error",
+            "message": "Type of \"append\" is partially unknown\n  Type of \"append\" is \"(object: Unknown, /) -> None\"",
+            "range": {
+                "start": {
+                    "line": 157,
+                    "character": 12
+                },
+                "end": {
+                    "line": 157,
+                    "character": 28
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/components/transparency.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"iterable\" in function \"join\"\n  Argument type is \"list[Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 159,
+                    "character": 31
+                },
+                "end": {
+                    "line": 159,
+                    "character": 40
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Stub file not found for \"pandas\"",
+            "range": {
+                "start": {
+                    "line": 8,
+                    "character": 7
+                },
+                "end": {
+                    "line": 8,
+                    "character": 13
+                }
+            },
+            "rule": "reportMissingTypeStubs"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Stub file not found for \"plotly.express\"",
+            "range": {
+                "start": {
+                    "line": 9,
+                    "character": 7
+                },
+                "end": {
+                    "line": 9,
+                    "character": 21
+                }
+            },
+            "rule": "reportMissingTypeStubs"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Argument of type \"list[str]\" cannot be assigned to parameter \"columns\" of type \"Axes | None\" in function \"__init__\"\n  Type \"list[str]\" is not assignable to type \"Axes | None\"\n    \"list[str]\" is not assignable to \"ExtensionArray\"\n    \"list[str]\" is not assignable to \"ndarray[_AnyShape, dtype[Any]]\"\n    \"list[str]\" is not assignable to \"Index\"\n    \"list[str]\" is not assignable to \"Series\"\n    \"list[str]\" is incompatible with protocol \"SequenceNotStr[Unknown]\"\n      \"index\" is an incompatible type\n        Type \"(value: str, start: SupportsIndex = 0, stop: SupportsIndex = sys.maxsize, /) -> int\" is not assignable to type \"(value: Any, /, start: int = 0, stop: int = ...) -> int\"\n  ...",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 36
+                },
+                "end": {
+                    "line": 30,
+                    "character": 55
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "No overloads for \"sum\" match the provided arguments",
+            "range": {
+                "start": {
+                    "line": 47,
+                    "character": 12
+                },
+                "end": {
+                    "line": 47,
+                    "character": 52
+                }
+            },
+            "rule": "reportCallIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Argument of type \"Generator[str | Any, None, None]\" cannot be assigned to parameter \"iterable\" of type \"Iterable[_SupportsSumNoDefaultT@sum]\" in function \"sum\"\n  \"Generator[str | Any, None, None]\" is not assignable to \"Iterable[_SupportsSumNoDefaultT@sum]\"\n    Type parameter \"_T_co@Iterable\" is covariant, but \"str | Any\" is not a subtype of \"_SupportsSumNoDefaultT@sum\"\n      Type \"str | Any\" is not assignable to type \"_SupportsSumWithNoDefaultGiven\"\n        Type \"str | Any\" is not assignable to type \"_SupportsSumWithNoDefaultGiven\"\n          \"str\" is incompatible with protocol \"_SupportsSumWithNoDefaultGiven\"",
+            "range": {
+                "start": {
+                    "line": 47,
+                    "character": 16
+                },
+                "end": {
+                    "line": 47,
+                    "character": 51
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"append\" is partially unknown\n  Type of \"append\" is \"(object: Unknown, /) -> None\"",
+            "range": {
+                "start": {
+                    "line": 51,
+                    "character": 8
+                },
+                "end": {
+                    "line": 51,
+                    "character": 22
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Argument of type \"list[str]\" cannot be assigned to parameter \"columns\" of type \"Axes | None\" in function \"__init__\"\n  Type \"list[str]\" is not assignable to type \"Axes | None\"\n    \"list[str]\" is not assignable to \"ExtensionArray\"\n    \"list[str]\" is not assignable to \"ndarray[_AnyShape, dtype[Any]]\"\n    \"list[str]\" is not assignable to \"Index\"\n    \"list[str]\" is not assignable to \"Series\"\n    \"list[str]\" is incompatible with protocol \"SequenceNotStr[Unknown]\"\n      \"index\" is an incompatible type\n        Type \"(value: str, start: SupportsIndex = 0, stop: SupportsIndex = sys.maxsize, /) -> int\" is not assignable to type \"(value: Any, /, start: int = 0, stop: int = ...) -> int\"\n  ...",
+            "range": {
+                "start": {
+                    "line": 52,
+                    "character": 41
+                },
+                "end": {
+                    "line": 52,
+                    "character": 60
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"line\" is partially unknown\n  Type of \"line\" is \"(data_frame: Unknown | None = None, x: Unknown | None = None, y: Unknown | None = None, line_group: Unknown | None = None, color: Unknown | None = None, line_dash: Unknown | None = None, symbol: Unknown | None = None, hover_name: Unknown | None = None, hover_data: Unknown | None = None, custom_data: Unknown | None = None, text: Unknown | None = None, facet_row: Unknown | None = None, facet_col: Unknown | None = None, facet_col_wrap: int = 0, facet_row_spacing: Unknown | None = None, facet_col_spacing: Unknown | None = None, error_x: Unknown | None = None, error_x_minus: Unknown | None = None, error_y: Unknown | None = None, error_y_minus: Unknown | None = None, animation_frame: Unknown | None = None, animation_group: Unknown | None = None, category_orders: Unknown | None = None, labels: Unknown | None = None, orientation: Unknown | None = None, color_discrete_sequence: Unknown | None = None, color_discrete_map: Unknown | None = None, line_dash_sequence: Unknown | None = None, line_dash_map: Unknown | None = None, symbol_sequence: Unknown | None = None, symbol_map: Unknown | None = None, markers: bool = False, log_x: bool = False, log_y: bool = False, range_x: Unknown | None = None, range_y: Unknown | None = None, line_shape: Unknown | None = None, render_mode: str = \"auto\", title: Unknown | None = None, subtitle: Unknown | None = None, template: Unknown | None = None, width: Unknown | None = None, height: Unknown | None = None) -> Figure\"",
+            "range": {
+                "start": {
+                    "line": 80,
+                    "character": 14
+                },
+                "end": {
+                    "line": 80,
+                    "character": 21
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"to_datetime\" is partially unknown\n  Type of \"to_datetime\" is \"Overload[(arg: float | str | date | datetime64[date | int | None], errors: Literal['ignore', 'raise', 'coerce'] = ..., dayfirst: bool = ..., yearfirst: bool = ..., utc: bool = ..., format: str | None = ..., exact: bool = ..., unit: str | None = ..., infer_datetime_format: bool = ..., origin: ... = ..., cache: bool = ...) -> Timestamp, (arg: Series | FulldatetimeDict | DataFrame, errors: Literal['ignore', 'raise', 'coerce'] = ..., dayfirst: bool = ..., yearfirst: bool = ..., utc: bool = ..., format: str | None = ..., exact: bool = ..., unit: str | None = ..., infer_datetime_format: bool = ..., origin: ... = ..., cache: bool = ...) -> Series, (arg: list[Unknown] | tuple[Unknown, ...] | Index | ExtensionArray | ndarray[tuple[Any, ...], dtype[Any]], errors: Literal['ignore', 'raise', 'coerce'] = ..., dayfirst: bool = ..., yearfirst: bool = ..., utc: bool = ..., format: str | None = ..., exact: bool = ..., unit: str | None = ..., infer_datetime_format: bool = ..., origin: ... = ..., cache: bool = ...) -> DatetimeIndex]\"",
+            "range": {
+                "start": {
+                    "line": 96,
+                    "character": 22
+                },
+                "end": {
+                    "line": 96,
+                    "character": 36
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"arg\" in function \"to_datetime\"\n  Argument type is \"Series | Unknown | DataFrame\"",
+            "range": {
+                "start": {
+                    "line": 96,
+                    "character": 37
+                },
+                "end": {
+                    "line": 96,
+                    "character": 52
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"avg_score\" is partially unknown\n  Type of \"avg_score\" is \"Series | float | int | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 97,
+                    "character": 4
+                },
+                "end": {
+                    "line": 97,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"mean\" is partially unknown\n  Type of \"mean\" is \"((axis: int | Literal['index', 'columns', 'rows'] | None = 0, skipna: bool = True, numeric_only: bool = False, **kwargs: Unknown) -> (Series | float)) | Unknown | ((axis: int | Literal['index', 'columns', 'rows'] | None = 0, skipna: bool = True, numeric_only: bool = False, **kwargs: Unknown) -> (Series | float | int))\"",
+            "range": {
+                "start": {
+                    "line": 97,
+                    "character": 16
+                },
+                "end": {
+                    "line": 97,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"line\" is partially unknown\n  Type of \"line\" is \"(data_frame: Unknown | None = None, x: Unknown | None = None, y: Unknown | None = None, line_group: Unknown | None = None, color: Unknown | None = None, line_dash: Unknown | None = None, symbol: Unknown | None = None, hover_name: Unknown | None = None, hover_data: Unknown | None = None, custom_data: Unknown | None = None, text: Unknown | None = None, facet_row: Unknown | None = None, facet_col: Unknown | None = None, facet_col_wrap: int = 0, facet_row_spacing: Unknown | None = None, facet_col_spacing: Unknown | None = None, error_x: Unknown | None = None, error_x_minus: Unknown | None = None, error_y: Unknown | None = None, error_y_minus: Unknown | None = None, animation_frame: Unknown | None = None, animation_group: Unknown | None = None, category_orders: Unknown | None = None, labels: Unknown | None = None, orientation: Unknown | None = None, color_discrete_sequence: Unknown | None = None, color_discrete_map: Unknown | None = None, line_dash_sequence: Unknown | None = None, line_dash_map: Unknown | None = None, symbol_sequence: Unknown | None = None, symbol_map: Unknown | None = None, markers: bool = False, log_x: bool = False, log_y: bool = False, range_x: Unknown | None = None, range_y: Unknown | None = None, line_shape: Unknown | None = None, render_mode: str = \"auto\", title: Unknown | None = None, subtitle: Unknown | None = None, template: Unknown | None = None, width: Unknown | None = None, height: Unknown | None = None) -> Figure\"",
+            "range": {
+                "start": {
+                    "line": 99,
+                    "character": 10
+                },
+                "end": {
+                    "line": 99,
+                    "character": 17
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"correlations\" is partially unknown\n  Type of \"correlations\" is \"str | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 105,
+                    "character": 4
+                },
+                "end": {
+                    "line": 105,
+                    "character": 16
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"corr\" is partially unknown\n  Type of \"corr\" is \"((other: Series, method: ((ndarray[tuple[Any, ...], dtype[Any]], ndarray[tuple[Any, ...], dtype[Any]]) -> float) | Literal['pearson', 'kendall', 'spearman'] = \"pearson\", min_periods: int | None = None) -> float) | Unknown | ((method: ((ndarray[tuple[Any, ...], dtype[Any]], ndarray[tuple[Any, ...], dtype[Any]]) -> float) | Literal['pearson', 'kendall', 'spearman'] = \"pearson\", min_periods: int = 1, numeric_only: bool = False) -> DataFrame)\"",
+            "range": {
+                "start": {
+                    "line": 106,
+                    "character": 8
+                },
+                "end": {
+                    "line": 107,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Argument missing for parameter \"other\"",
+            "range": {
+                "start": {
+                    "line": 106,
+                    "character": 8
+                },
+                "end": {
+                    "line": 107,
+                    "character": 15
+                }
+            },
+            "rule": "reportCallIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"to_string\" is partially unknown\n  Type of \"to_string\" is \"Overload[(buf: None = ..., columns: ExtensionArray | ndarray[tuple[Any, ...], dtype[Any]] | Index | Series | SequenceNotStr[Unknown] | range | None = ..., col_space: int | list[int] | dict[Hashable, int] | None = ..., header: bool | SequenceNotStr[str] = ..., index: bool = ..., na_rep: str = ..., formatters: list[(...) -> Unknown] | tuple[(...) -> Unknown, ...] | Mapping[str | int, (...) -> Unknown] | None = ..., float_format: str | ((...) -> Unknown) | EngFormatter | None = ..., sparsify: bool | None = ..., index_names: bool = ..., justify: str | None = ..., max_rows: int | None = ..., max_cols: int | None = ..., show_dimensions: bool = ..., decimal: str = ..., line_width: int | None = ..., min_rows: int | None = ..., max_colwidth: int | None = ..., encoding: str | None = ...) -> str, (buf: str | PathLike[str] | WriteBuffer[str], columns: ExtensionArray | ndarray[tuple[Any, ...], dtype[Any]] | Index | Series | SequenceNotStr[Unknown] | range | None = ..., col_space: int | list[int] | dict[Hashable, int] | None = ..., header: bool | SequenceNotStr[str] = ..., index: bool = ..., na_rep: str = ..., formatters: list[(...) -> Unknown] | tuple[(...) -> Unknown, ...] | Mapping[str | int, (...) -> Unknown] | None = ..., float_format: str | ((...) -> Unknown) | EngFormatter | None = ..., sparsify: bool | None = ..., index_names: bool = ..., justify: str | None = ..., max_rows: int | None = ..., max_cols: int | None = ..., show_dimensions: bool = ..., decimal: str = ..., line_width: int | None = ..., min_rows: int | None = ..., max_colwidth: int | None = ..., encoding: str | None = ...) -> None] | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 106,
+                    "character": 8
+                },
+                "end": {
+                    "line": 108,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"alerts_df\" is partially unknown\n  Type of \"alerts_df\" is \"Series | Any | ndarray[tuple[Any, ...], dtype[Any]] | Unknown | DataFrame\"",
+            "range": {
+                "start": {
+                    "line": 115,
+                    "character": 4
+                },
+                "end": {
+                    "line": 115,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"empty\" is partially unknown\n  Type of \"empty\" is \"bool | Any | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 120,
+                    "character": 7
+                },
+                "end": {
+                    "line": 120,
+                    "character": 22
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Cannot access attribute \"empty\" for class \"ndarray[_AnyShape, dtype[Any]]\"\n  Attribute \"empty\" is unknown",
+            "range": {
+                "start": {
+                    "line": 120,
+                    "character": 17
+                },
+                "end": {
+                    "line": 120,
+                    "character": 22
+                }
+            },
+            "rule": "reportAttributeAccessIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"alerts\" is partially unknown\n  Type of \"alerts\" is \"str | Any | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 123,
+                    "character": 8
+                },
+                "end": {
+                    "line": 123,
+                    "character": 14
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"to_string\" is partially unknown\n  Type of \"to_string\" is \"Overload[(buf: None = ..., na_rep: str = ..., float_format: str | None = ..., header: bool = ..., index: bool = ..., length: bool = ..., dtype: ... = ..., name: ... = ..., max_rows: int | None = ..., min_rows: int | None = ...) -> str, (buf: str | PathLike[str] | WriteBuffer[str], na_rep: str = ..., float_format: str | None = ..., header: bool = ..., index: bool = ..., length: bool = ..., dtype: ... = ..., name: ... = ..., max_rows: int | None = ..., min_rows: int | None = ...) -> None] | Any | Unknown | Overload[(buf: None = ..., columns: ExtensionArray | ndarray[tuple[Any, ...], dtype[Any]] | Index | Series | SequenceNotStr[Unknown] | range | None = ..., col_space: int | list[int] | dict[Hashable, int] | None = ..., header: bool | SequenceNotStr[str] = ..., index: bool = ..., na_rep: str = ..., formatters: list[(...) -> Unknown] | tuple[(...) -> Unknown, ...] | Mapping[str | int, (...) -> Unknown] | None = ..., float_format: str | ((...) -> Unknown) | EngFormatter | None = ..., sparsify: bool | None = ..., index_names: bool = ..., justify: str | None = ..., max_rows: int | None = ..., max_cols: int | None = ..., show_dimensions: bool = ..., decimal: str = ..., line_width: int | None = ..., min_rows: int | None = ..., max_colwidth: int | None = ..., encoding: str | None = ...) -> str, (buf: str | PathLike[str] | WriteBuffer[str], columns: ExtensionArray | ndarray[tuple[Any, ...], dtype[Any]] | Index | Series | SequenceNotStr[Unknown] | range | None = ..., col_space: int | list[int] | dict[Hashable, int] | None = ..., header: bool | SequenceNotStr[str] = ..., index: bool = ..., na_rep: str = ..., formatters: list[(...) -> Unknown] | tuple[(...) -> Unknown, ...] | Mapping[str | int, (...) -> Unknown] | None = ..., float_format: str | ((...) -> Unknown) | EngFormatter | None = ..., sparsify: bool | None = ..., index_names: bool = ..., justify: str | None = ..., max_rows: int | None = ..., max_cols: int | None = ..., show_dimensions: bool = ..., decimal: str = ..., line_width: int | None = ..., min_rows: int | None = ..., max_colwidth: int | None = ..., encoding: str | None = ...) -> None]\"",
+            "range": {
+                "start": {
+                    "line": 123,
+                    "character": 17
+                },
+                "end": {
+                    "line": 123,
+                    "character": 36
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Cannot access attribute \"to_string\" for class \"ndarray[_AnyShape, dtype[Any]]\"\n  Attribute \"to_string\" is unknown",
+            "range": {
+                "start": {
+                    "line": 123,
+                    "character": 27
+                },
+                "end": {
+                    "line": 123,
+                    "character": 36
+                }
+            },
+            "rule": "reportAttributeAccessIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"avg_relevancy\" is partially unknown\n  Type of \"avg_relevancy\" is \"Series | float | int | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 124,
+                    "character": 4
+                },
+                "end": {
+                    "line": 124,
+                    "character": 17
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"mean\" is partially unknown\n  Type of \"mean\" is \"((axis: int | Literal['index', 'columns', 'rows'] | None = 0, skipna: bool = True, numeric_only: bool = False, **kwargs: Unknown) -> (Series | float)) | Unknown | ((axis: int | Literal['index', 'columns', 'rows'] | None = 0, skipna: bool = True, numeric_only: bool = False, **kwargs: Unknown) -> (Series | float | int))\"",
+            "range": {
+                "start": {
+                    "line": 124,
+                    "character": 20
+                },
+                "end": {
+                    "line": 124,
+                    "character": 40
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"avg_precision\" is partially unknown\n  Type of \"avg_precision\" is \"Series | float | int | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 125,
+                    "character": 4
+                },
+                "end": {
+                    "line": 125,
+                    "character": 17
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"mean\" is partially unknown\n  Type of \"mean\" is \"((axis: int | Literal['index', 'columns', 'rows'] | None = 0, skipna: bool = True, numeric_only: bool = False, **kwargs: Unknown) -> (Series | float)) | Unknown | ((axis: int | Literal['index', 'columns', 'rows'] | None = 0, skipna: bool = True, numeric_only: bool = False, **kwargs: Unknown) -> (Series | float | int))\"",
+            "range": {
+                "start": {
+                    "line": 125,
+                    "character": 20
+                },
+                "end": {
+                    "line": 125,
+                    "character": 40
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"avg_faithfulness\" is partially unknown\n  Type of \"avg_faithfulness\" is \"Series | float | int | Unknown\"",
+            "range": {
+                "start": {
+                    "line": 126,
+                    "character": 4
+                },
+                "end": {
+                    "line": 126,
+                    "character": 20
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"mean\" is partially unknown\n  Type of \"mean\" is \"((axis: int | Literal['index', 'columns', 'rows'] | None = 0, skipna: bool = True, numeric_only: bool = False, **kwargs: Unknown) -> (Series | float)) | Unknown | ((axis: int | Literal['index', 'columns', 'rows'] | None = 0, skipna: bool = True, numeric_only: bool = False, **kwargs: Unknown) -> (Series | float | int))\"",
+            "range": {
+                "start": {
+                    "line": 126,
+                    "character": 23
+                },
+                "end": {
+                    "line": 126,
+                    "character": 46
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Argument of type \"dict[str, Series | float | int | Unknown]\" cannot be assigned to parameter \"metrics\" of type \"Dict[str, float]\" in function \"generate_recommendations\"\n  Type \"Series | float | int | Unknown\" is not assignable to type \"float\"\n    \"Series\" is not assignable to \"float\"\n  Type \"Series | float | int | Unknown\" is not assignable to type \"float\"\n    \"Series\" is not assignable to \"float\"\n  Type \"Series | float | int | Unknown\" is not assignable to type \"float\"\n    \"Series\" is not assignable to \"float\"",
+            "range": {
+                "start": {
+                    "line": 128,
+                    "character": 8
+                },
+                "end": {
+                    "line": 132,
+                    "character": 9
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"to_csv\" is partially unknown\n  Type of \"to_csv\" is \"Overload[(path_or_buf: None = ..., sep: str = ..., na_rep: str = ..., float_format: str | ((...) -> Unknown) | None = ..., columns: Sequence[Hashable] | None = ..., header: bool | list[str] = ..., index: bool = ..., index_label: Hashable | Sequence[Hashable] | None = ..., mode: str = ..., encoding: str | None = ..., compression: dict[str, Any] | Literal['infer', 'gzip', 'bz2', 'zip', 'xz', 'zstd', 'tar'] | None = ..., quoting: int | None = ..., quotechar: str = ..., lineterminator: str | None = ..., chunksize: int | None = ..., date_format: str | None = ..., doublequote: bool = ..., escapechar: str | None = ..., decimal: str = ..., errors: Literal['strict', 'ignore', 'replace', 'surrogateescape', 'xmlcharrefreplace', 'backslashreplace', 'namereplace'] = ..., storage_options: dict[str, Any] | None = ...) -> str, (path_or_buf: str | PathLike[str] | WriteBuffer[bytes] | WriteBuffer[str], sep: str = ..., na_rep: str = ..., float_format: str | ((...) -> Unknown) | None = ..., columns: Sequence[Hashable] | None = ..., header: bool | list[str] = ..., index: bool = ..., index_label: Hashable | Sequence[Hashable] | None = ..., mode: str = ..., encoding: str | None = ..., compression: dict[str, Any] | Literal['infer', 'gzip', 'bz2', 'zip', 'xz', 'zstd', 'tar'] | None = ..., quoting: int | None = ..., quotechar: str = ..., lineterminator: str | None = ..., chunksize: int | None = ..., date_format: str | None = ..., doublequote: bool = ..., escapechar: str | None = ..., decimal: str = ..., errors: Literal['strict', 'ignore', 'replace', 'surrogateescape', 'xmlcharrefreplace', 'backslashreplace', 'namereplace'] = ..., storage_options: dict[str, Any] | None = ...) -> None]\"",
+            "range": {
+                "start": {
+                    "line": 139,
+                    "character": 16
+                },
+                "end": {
+                    "line": 139,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type of \"to_json\" is partially unknown\n  Type of \"to_json\" is \"(path_or_buf: str | PathLike[str] | WriteBuffer[bytes] | WriteBuffer[str] | None = None, orient: Literal['split', 'records', 'index', 'table', 'columns', 'values'] | None = None, date_format: str | None = None, double_precision: int = 10, force_ascii: bool = True, date_unit: Literal['s', 'ms', 'us', 'ns'] = \"ms\", default_handler: ((Any) -> (str | float | bool | list[Unknown] | dict[Unknown, Unknown] | None)) | None = None, lines: bool = False, compression: dict[str, Any] | Literal['infer', 'gzip', 'bz2', 'zip', 'xz', 'zstd', 'tar'] | None = \"infer\", index: bool | None = None, indent: int | None = None, storage_options: dict[str, Any] | None = None, mode: Literal['a', 'w'] = \"w\") -> (str | None)\"",
+            "range": {
+                "start": {
+                    "line": 140,
+                    "character": 17
+                },
+                "end": {
+                    "line": 140,
+                    "character": 27
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "\"encode\" is not a known attribute of \"None\"",
+            "range": {
+                "start": {
+                    "line": 140,
+                    "character": 46
+                },
+                "end": {
+                    "line": 140,
+                    "character": 52
+                }
+            },
+            "rule": "reportOptionalMemberAccess"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[str, Figure, Series | Unknown | DataFrame, str | Unknown, str | Any | Unknown, str, dict[str, Any], dict[str, Any]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 143,
+                    "character": 11
+                },
+                "end": {
+                    "line": 161,
+                    "character": 5
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/evaluate.py",
+            "severity": "error",
+            "message": "Type \"tuple[str, Figure, Series | Unknown | DataFrame, str | Unknown, str | Any | Unknown, str, dict[str, Any], dict[str, Any]]\" is not assignable to return type \"Tuple[str, Any, DataFrame, str, str, str, Dict[str, Any], Dict[str, Any]]\"\n  Type \"Series | Unknown | DataFrame\" is not assignable to type \"DataFrame\"\n    \"Series\" is not assignable to \"DataFrame\"",
+            "range": {
+                "start": {
+                    "line": 146,
+                    "character": 8
+                },
+                "end": {
+                    "line": 155,
+                    "character": 9
+                }
+            },
+            "rule": "reportReturnType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[Unknown], dict[Unknown, Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 24,
+                    "character": 8
+                },
+                "end": {
+                    "line": 24,
+                    "character": 20
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"args\" is unknown",
+            "range": {
+                "start": {
+                    "line": 24,
+                    "character": 28
+                },
+                "end": {
+                    "line": 24,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"args\"",
+            "range": {
+                "start": {
+                    "line": 24,
+                    "character": 28
+                },
+                "end": {
+                    "line": 24,
+                    "character": 32
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"kwargs\" is unknown",
+            "range": {
+                "start": {
+                    "line": 24,
+                    "character": 36
+                },
+                "end": {
+                    "line": 24,
+                    "character": 42
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"kwargs\"",
+            "range": {
+                "start": {
+                    "line": 24,
+                    "character": 36
+                },
+                "end": {
+                    "line": 24,
+                    "character": 42
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[Unknown], dict[Unknown, Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 25,
+                    "character": 15
+                },
+                "end": {
+                    "line": 25,
+                    "character": 21
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 27,
+                    "character": 8
+                },
+                "end": {
+                    "line": 27,
+                    "character": 23
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"args\" is unknown",
+            "range": {
+                "start": {
+                    "line": 27,
+                    "character": 31
+                },
+                "end": {
+                    "line": 27,
+                    "character": 35
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"args\"",
+            "range": {
+                "start": {
+                    "line": 27,
+                    "character": 31
+                },
+                "end": {
+                    "line": 27,
+                    "character": 35
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"kwargs\" is unknown",
+            "range": {
+                "start": {
+                    "line": 27,
+                    "character": 39
+                },
+                "end": {
+                    "line": 27,
+                    "character": 45
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"kwargs\"",
+            "range": {
+                "start": {
+                    "line": 27,
+                    "character": 39
+                },
+                "end": {
+                    "line": 27,
+                    "character": 45
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 28,
+                    "character": 15
+                },
+                "end": {
+                    "line": 28,
+                    "character": 17
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 8
+                },
+                "end": {
+                    "line": 30,
+                    "character": 23
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"args\" is unknown",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 31
+                },
+                "end": {
+                    "line": 30,
+                    "character": 35
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"args\"",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 31
+                },
+                "end": {
+                    "line": 30,
+                    "character": 35
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"kwargs\" is unknown",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 39
+                },
+                "end": {
+                    "line": 30,
+                    "character": 45
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"kwargs\"",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 39
+                },
+                "end": {
+                    "line": 30,
+                    "character": 45
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 31,
+                    "character": 15
+                },
+                "end": {
+                    "line": 31,
+                    "character": 17
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[Literal[True], dict[Unknown, Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 33,
+                    "character": 8
+                },
+                "end": {
+                    "line": 33,
+                    "character": 22
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"args\" is unknown",
+            "range": {
+                "start": {
+                    "line": 33,
+                    "character": 30
+                },
+                "end": {
+                    "line": 33,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"args\"",
+            "range": {
+                "start": {
+                    "line": 33,
+                    "character": 30
+                },
+                "end": {
+                    "line": 33,
+                    "character": 34
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"kwargs\" is unknown",
+            "range": {
+                "start": {
+                    "line": 33,
+                    "character": 38
+                },
+                "end": {
+                    "line": 33,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"kwargs\"",
+            "range": {
+                "start": {
+                    "line": 33,
+                    "character": 38
+                },
+                "end": {
+                    "line": 33,
+                    "character": 44
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[Literal[True], dict[Unknown, Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 34,
+                    "character": 15
+                },
+                "end": {
+                    "line": 34,
+                    "character": 23
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[Unknown], dict[Unknown, Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 40,
+                    "character": 8
+                },
+                "end": {
+                    "line": 40,
+                    "character": 23
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"args\" is unknown",
+            "range": {
+                "start": {
+                    "line": 40,
+                    "character": 31
+                },
+                "end": {
+                    "line": 40,
+                    "character": 35
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"args\"",
+            "range": {
+                "start": {
+                    "line": 40,
+                    "character": 31
+                },
+                "end": {
+                    "line": 40,
+                    "character": 35
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"kwargs\" is unknown",
+            "range": {
+                "start": {
+                    "line": 40,
+                    "character": 39
+                },
+                "end": {
+                    "line": 40,
+                    "character": 45
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"kwargs\"",
+            "range": {
+                "start": {
+                    "line": 40,
+                    "character": 39
+                },
+                "end": {
+                    "line": 40,
+                    "character": 45
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[Unknown], dict[Unknown, Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 41,
+                    "character": 15
+                },
+                "end": {
+                    "line": 41,
+                    "character": 21
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Argument of type \"_DummyDenseRetriever\" cannot be assigned to parameter \"dense_retriever\" of type \"DenseRetriever\" in function \"__init__\"\n  \"_DummyDenseRetriever\" is not assignable to \"DenseRetriever\"",
+            "range": {
+                "start": {
+                    "line": 45,
+                    "character": 4
+                },
+                "end": {
+                    "line": 45,
+                    "character": 26
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Argument of type \"_DummyLexicalRetriever\" cannot be assigned to parameter \"lexical_retriever\" of type \"LexicalBM25\" in function \"__init__\"\n  \"_DummyLexicalRetriever\" is not assignable to \"LexicalBM25\"",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 4
+                },
+                "end": {
+                    "line": 46,
+                    "character": 28
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type of \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 78,
+                    "character": 32
+                },
+                "end": {
+                    "line": 78,
+                    "character": 41
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"name\" in function \"_sanitize_name\"",
+            "range": {
+                "start": {
+                    "line": 78,
+                    "character": 32
+                },
+                "end": {
+                    "line": 78,
+                    "character": 41
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Cannot access attribute \"name\" for class \"File\"\n  Attribute \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 78,
+                    "character": 37
+                },
+                "end": {
+                    "line": 78,
+                    "character": 41
+                }
+            },
+            "rule": "reportAttributeAccessIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type of \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 80,
+                    "character": 39
+                },
+                "end": {
+                    "line": 80,
+                    "character": 48
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"path_str\" in function \"_sanitize_path\"",
+            "range": {
+                "start": {
+                    "line": 80,
+                    "character": 39
+                },
+                "end": {
+                    "line": 80,
+                    "character": 48
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Cannot access attribute \"name\" for class \"File\"\n  Attribute \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 80,
+                    "character": 44
+                },
+                "end": {
+                    "line": 80,
+                    "character": 48
+                }
+            },
+            "rule": "reportAttributeAccessIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Type of \"metadata\" is partially unknown\n  Type of \"metadata\" is \"Any | dict[Unknown, Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 139,
+                    "character": 8
+                },
+                "end": {
+                    "line": 139,
+                    "character": 16
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/ingest.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"metadata\" in function \"update_document\"\n  Argument type is \"Any | dict[Unknown, Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 142,
+                    "character": 62
+                },
+                "end": {
+                    "line": 142,
+                    "character": 70
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Stub file not found for \"pandas\"",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 7
+                },
+                "end": {
+                    "line": 7,
+                    "character": 13
+                }
+            },
+            "rule": "reportMissingTypeStubs"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "\"_latencies\" is protected and used outside of the class in which it is declared",
+            "range": {
+                "start": {
+                    "line": 45,
+                    "character": 45
+                },
+                "end": {
+                    "line": 45,
+                    "character": 55
+                }
+            },
+            "rule": "reportPrivateUsage"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of parameter \"file\" is unknown",
+            "range": {
+                "start": {
+                    "line": 62,
+                    "character": 28
+                },
+                "end": {
+                    "line": 62,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"file\"",
+            "range": {
+                "start": {
+                    "line": 62,
+                    "character": 28
+                },
+                "end": {
+                    "line": 62,
+                    "character": 32
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 70,
+                    "character": 44
+                },
+                "end": {
+                    "line": 70,
+                    "character": 53
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"path\" in function \"load_settings\"",
+            "range": {
+                "start": {
+                    "line": 70,
+                    "character": 44
+                },
+                "end": {
+                    "line": 70,
+                    "character": 53
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Variable \"errors\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 71,
+                    "character": 19
+                },
+                "end": {
+                    "line": 71,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnusedVariable"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"fn\" in function \"change\"\n  Argument type is \"(v: Unknown, s: Unknown) -> Tuple[Dict[str, Any], str]\"",
+            "range": {
+                "start": {
+                    "line": 110,
+                    "character": 20
+                },
+                "end": {
+                    "line": 110,
+                    "character": 60
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of parameter \"v\" is unknown",
+            "range": {
+                "start": {
+                    "line": 110,
+                    "character": 27
+                },
+                "end": {
+                    "line": 110,
+                    "character": 28
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of parameter \"s\" is unknown",
+            "range": {
+                "start": {
+                    "line": 110,
+                    "character": 30
+                },
+                "end": {
+                    "line": 110,
+                    "character": 31
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"settings\" in function \"update_field\"",
+            "range": {
+                "start": {
+                    "line": 110,
+                    "character": 58
+                },
+                "end": {
+                    "line": 110,
+                    "character": 59
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"fn\" in function \"change\"\n  Argument type is \"(v: Unknown, s: Unknown) -> Tuple[Dict[str, Any], str]\"",
+            "range": {
+                "start": {
+                    "line": 115,
+                    "character": 20
+                },
+                "end": {
+                    "line": 115,
+                    "character": 60
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of parameter \"v\" is unknown",
+            "range": {
+                "start": {
+                    "line": 115,
+                    "character": 27
+                },
+                "end": {
+                    "line": 115,
+                    "character": 28
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of parameter \"s\" is unknown",
+            "range": {
+                "start": {
+                    "line": 115,
+                    "character": 30
+                },
+                "end": {
+                    "line": 115,
+                    "character": 31
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"settings\" in function \"update_field\"",
+            "range": {
+                "start": {
+                    "line": 115,
+                    "character": 58
+                },
+                "end": {
+                    "line": 115,
+                    "character": 59
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "\"_latencies\" is protected and used outside of the class in which it is declared",
+            "range": {
+                "start": {
+                    "line": 137,
+                    "character": 57
+                },
+                "end": {
+                    "line": 137,
+                    "character": 67
+                }
+            },
+            "rule": "reportPrivateUsage"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "\"_latencies\" is protected and used outside of the class in which it is declared",
+            "range": {
+                "start": {
+                    "line": 138,
+                    "character": 56
+                },
+                "end": {
+                    "line": 138,
+                    "character": 66
+                }
+            },
+            "rule": "reportPrivateUsage"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"fn\" in function \"change\"\n  Argument type is \"(v: Unknown, s: Unknown) -> Tuple[Dict[str, Any], str]\"",
+            "range": {
+                "start": {
+                    "line": 180,
+                    "character": 20
+                },
+                "end": {
+                    "line": 180,
+                    "character": 75
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of parameter \"v\" is unknown",
+            "range": {
+                "start": {
+                    "line": 180,
+                    "character": 27
+                },
+                "end": {
+                    "line": 180,
+                    "character": 28
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of parameter \"s\" is unknown",
+            "range": {
+                "start": {
+                    "line": 180,
+                    "character": 30
+                },
+                "end": {
+                    "line": 180,
+                    "character": 31
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"settings\" in function \"update_policy_field\"",
+            "range": {
+                "start": {
+                    "line": 180,
+                    "character": 73
+                },
+                "end": {
+                    "line": 180,
+                    "character": 74
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"fn\" in function \"change\"\n  Argument type is \"(v: Unknown, s: Unknown) -> Tuple[Dict[str, Any], str]\"",
+            "range": {
+                "start": {
+                    "line": 185,
+                    "character": 20
+                },
+                "end": {
+                    "line": 185,
+                    "character": 71
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of parameter \"v\" is unknown",
+            "range": {
+                "start": {
+                    "line": 185,
+                    "character": 27
+                },
+                "end": {
+                    "line": 185,
+                    "character": 28
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of parameter \"s\" is unknown",
+            "range": {
+                "start": {
+                    "line": 185,
+                    "character": 30
+                },
+                "end": {
+                    "line": 185,
+                    "character": 31
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"settings\" in function \"update_policy_field\"",
+            "range": {
+                "start": {
+                    "line": 185,
+                    "character": 69
+                },
+                "end": {
+                    "line": 185,
+                    "character": 70
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"fn\" in function \"change\"\n  Argument type is \"(v: Unknown, s: Unknown) -> Tuple[Dict[str, Any], str]\"",
+            "range": {
+                "start": {
+                    "line": 190,
+                    "character": 20
+                },
+                "end": {
+                    "line": 190,
+                    "character": 86
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of parameter \"v\" is unknown",
+            "range": {
+                "start": {
+                    "line": 190,
+                    "character": 27
+                },
+                "end": {
+                    "line": 190,
+                    "character": 28
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of parameter \"s\" is unknown",
+            "range": {
+                "start": {
+                    "line": 190,
+                    "character": 30
+                },
+                "end": {
+                    "line": 190,
+                    "character": 31
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"settings\" in function \"update_policy_field\"",
+            "range": {
+                "start": {
+                    "line": 190,
+                    "character": 84
+                },
+                "end": {
+                    "line": 190,
+                    "character": 85
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"fn\" in function \"change\"\n  Argument type is \"(v: Unknown, s: Unknown) -> Tuple[Dict[str, Any], str]\"",
+            "range": {
+                "start": {
+                    "line": 195,
+                    "character": 20
+                },
+                "end": {
+                    "line": 195,
+                    "character": 79
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of parameter \"v\" is unknown",
+            "range": {
+                "start": {
+                    "line": 195,
+                    "character": 27
+                },
+                "end": {
+                    "line": 195,
+                    "character": 28
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of parameter \"s\" is unknown",
+            "range": {
+                "start": {
+                    "line": 195,
+                    "character": 30
+                },
+                "end": {
+                    "line": 195,
+                    "character": 31
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"settings\" in function \"update_policy_field\"",
+            "range": {
+                "start": {
+                    "line": 195,
+                    "character": 77
+                },
+                "end": {
+                    "line": 195,
+                    "character": 78
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"fn\" in function \"change\"\n  Argument type is \"(v: Unknown, s: Unknown) -> Tuple[Dict[str, Any], str]\"",
+            "range": {
+                "start": {
+                    "line": 200,
+                    "character": 20
+                },
+                "end": {
+                    "line": 200,
+                    "character": 68
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of parameter \"v\" is unknown",
+            "range": {
+                "start": {
+                    "line": 200,
+                    "character": 27
+                },
+                "end": {
+                    "line": 200,
+                    "character": 28
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of parameter \"s\" is unknown",
+            "range": {
+                "start": {
+                    "line": 200,
+                    "character": 30
+                },
+                "end": {
+                    "line": 200,
+                    "character": 31
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"settings\" in function \"update_field\"",
+            "range": {
+                "start": {
+                    "line": 200,
+                    "character": 66
+                },
+                "end": {
+                    "line": 200,
+                    "character": 67
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"fn\" in function \"click\"\n  Argument type is \"(m: Unknown) -> Any\"",
+            "range": {
+                "start": {
+                    "line": 210,
+                    "character": 20
+                },
+                "end": {
+                    "line": 214,
+                    "character": 21
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Type of parameter \"m\" is unknown",
+            "range": {
+                "start": {
+                    "line": 210,
+                    "character": 27
+                },
+                "end": {
+                    "line": 210,
+                    "character": 28
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"mode\" in function \"get_latency_trend\"",
+            "range": {
+                "start": {
+                    "line": 213,
+                    "character": 42
+                },
+                "end": {
+                    "line": 213,
+                    "character": 43
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/ui/settings.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"fn\" in function \"change\"\n  Argument type is \"(file: Unknown, settings: Dict[str, Any]) -> (tuple[Dict[str, Any], Literal[''], Any | None, Any | None] | tuple[Dict[str, Any], Literal['Invalid configuration'], Any | None, Any | None])\"",
+            "range": {
+                "start": {
+                    "line": 231,
+                    "character": 20
+                },
+                "end": {
+                    "line": 231,
+                    "character": 35
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/utils/hardware.py",
+            "severity": "error",
+            "message": "Type of \"core\" is unknown",
+            "range": {
+                "start": {
+                    "line": 14,
+                    "character": 8
+                },
+                "end": {
+                    "line": 14,
+                    "character": 12
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/src/utils/hardware.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"o\" in function \"getattr\"",
+            "range": {
+                "start": {
+                    "line": 15,
+                    "character": 26
+                },
+                "end": {
+                    "line": 15,
+                    "character": 30
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 13,
+                    "character": 7
+                },
+                "end": {
+                    "line": 13,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of parameter \"warning_message\" is unknown",
+            "range": {
+                "start": {
+                    "line": 19,
+                    "character": 28
+                },
+                "end": {
+                    "line": 19,
+                    "character": 43
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"warning_message\"",
+            "range": {
+                "start": {
+                    "line": 19,
+                    "character": 28
+                },
+                "end": {
+                    "line": 19,
+                    "character": 43
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of parameter \"when\" is unknown",
+            "range": {
+                "start": {
+                    "line": 19,
+                    "character": 45
+                },
+                "end": {
+                    "line": 19,
+                    "character": 49
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"when\"",
+            "range": {
+                "start": {
+                    "line": 19,
+                    "character": 45
+                },
+                "end": {
+                    "line": 19,
+                    "character": 49
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of parameter \"nodeid\" is unknown",
+            "range": {
+                "start": {
+                    "line": 19,
+                    "character": 51
+                },
+                "end": {
+                    "line": 19,
+                    "character": 57
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"nodeid\"",
+            "range": {
+                "start": {
+                    "line": 19,
+                    "character": 51
+                },
+                "end": {
+                    "line": 19,
+                    "character": 57
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of parameter \"location\" is unknown",
+            "range": {
+                "start": {
+                    "line": 19,
+                    "character": 59
+                },
+                "end": {
+                    "line": 19,
+                    "character": 67
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"location\"",
+            "range": {
+                "start": {
+                    "line": 19,
+                    "character": 59
+                },
+                "end": {
+                    "line": 19,
+                    "character": 67
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of \"message\" is unknown",
+            "range": {
+                "start": {
+                    "line": 31,
+                    "character": 27
+                },
+                "end": {
+                    "line": 31,
+                    "character": 50
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"object\" in function \"__new__\"",
+            "range": {
+                "start": {
+                    "line": 31,
+                    "character": 27
+                },
+                "end": {
+                    "line": 31,
+                    "character": 50
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of \"category\" is unknown",
+            "range": {
+                "start": {
+                    "line": 32,
+                    "character": 24
+                },
+                "end": {
+                    "line": 32,
+                    "character": 48
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of \"__name__\" is unknown",
+            "range": {
+                "start": {
+                    "line": 32,
+                    "character": 24
+                },
+                "end": {
+                    "line": 32,
+                    "character": 57
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of \"filename\" is unknown",
+            "range": {
+                "start": {
+                    "line": 33,
+                    "character": 24
+                },
+                "end": {
+                    "line": 33,
+                    "character": 48
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of \"lineno\" is unknown",
+            "range": {
+                "start": {
+                    "line": 34,
+                    "character": 22
+                },
+                "end": {
+                    "line": 34,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of parameter \"session\" is unknown",
+            "range": {
+                "start": {
+                    "line": 41,
+                    "character": 25
+                },
+                "end": {
+                    "line": 41,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"session\"",
+            "range": {
+                "start": {
+                    "line": 41,
+                    "character": 25
+                },
+                "end": {
+                    "line": 41,
+                    "character": 32
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of parameter \"exitstatus\" is unknown",
+            "range": {
+                "start": {
+                    "line": 41,
+                    "character": 34
+                },
+                "end": {
+                    "line": 41,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"exitstatus\"",
+            "range": {
+                "start": {
+                    "line": 41,
+                    "character": 34
+                },
+                "end": {
+                    "line": 41,
+                    "character": 44
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of \"config\" is unknown",
+            "range": {
+                "start": {
+                    "line": 47,
+                    "character": 12
+                },
+                "end": {
+                    "line": 47,
+                    "character": 26
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of \"rootdir\" is unknown",
+            "range": {
+                "start": {
+                    "line": 47,
+                    "character": 12
+                },
+                "end": {
+                    "line": 47,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"object\" in function \"__new__\"",
+            "range": {
+                "start": {
+                    "line": 47,
+                    "character": 12
+                },
+                "end": {
+                    "line": 47,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of \"tr\" is unknown",
+            "range": {
+                "start": {
+                    "line": 84,
+                    "character": 4
+                },
+                "end": {
+                    "line": 84,
+                    "character": 6
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of \"config\" is unknown",
+            "range": {
+                "start": {
+                    "line": 84,
+                    "character": 9
+                },
+                "end": {
+                    "line": 84,
+                    "character": 23
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of \"pluginmanager\" is unknown",
+            "range": {
+                "start": {
+                    "line": 84,
+                    "character": 9
+                },
+                "end": {
+                    "line": 84,
+                    "character": 37
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of \"get_plugin\" is unknown",
+            "range": {
+                "start": {
+                    "line": 84,
+                    "character": 9
+                },
+                "end": {
+                    "line": 84,
+                    "character": 48
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/conftest.py",
+            "severity": "error",
+            "message": "Type of \"write_line\" is unknown",
+            "range": {
+                "start": {
+                    "line": 86,
+                    "character": 8
+                },
+                "end": {
+                    "line": 86,
+                    "character": 21
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_app.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_config/test_backup.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_config/test_backup.py",
+            "severity": "error",
+            "message": "Type of \"backup_config\" is partially unknown\n  Type of \"backup_config\" is \"(path: str, backup_dir: str) -> Tuple[Path, dict[Unknown, Unknown]]\"",
+            "range": {
+                "start": {
+                    "line": 6,
+                    "character": 30
+                },
+                "end": {
+                    "line": 6,
+                    "character": 43
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_config/test_backup.py",
+            "severity": "error",
+            "message": "Type of \"restore_config\" is partially unknown\n  Type of \"restore_config\" is \"(backup_path: str, target_path: str) -> Tuple[Path, dict[Unknown, Unknown]]\"",
+            "range": {
+                "start": {
+                    "line": 6,
+                    "character": 45
+                },
+                "end": {
+                    "line": 6,
+                    "character": 59
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_config/test_backup.py",
+            "severity": "error",
+            "message": "Type of \"_\" is partially unknown\n  Type of \"_\" is \"dict[Unknown, Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 13,
+                    "character": 17
+                },
+                "end": {
+                    "line": 13,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_config/test_runtime_config.py",
+            "severity": "error",
+            "message": "Type of parameter \"cfg\" is unknown",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 17
+                },
+                "end": {
+                    "line": 46,
+                    "character": 20
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_config/test_runtime_config.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"cfg\"",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 17
+                },
+                "end": {
+                    "line": 46,
+                    "character": 20
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_config/test_runtime_config.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"object\" in function \"append\"",
+            "range": {
+                "start": {
+                    "line": 47,
+                    "character": 22
+                },
+                "end": {
+                    "line": 47,
+                    "character": 64
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_config/test_runtime_config.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"callback\" in function \"register\"\n  Argument type is \"(cfg: Unknown) -> None\"",
+            "range": {
+                "start": {
+                    "line": 49,
+                    "character": 25
+                },
+                "end": {
+                    "line": 49,
+                    "character": 33
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_config/test_runtime_config_errors.py",
+            "severity": "error",
+            "message": "Type of parameter \"cfg\" is unknown",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 22
+                },
+                "end": {
+                    "line": 7,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_config/test_runtime_config_errors.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"cfg\"",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 22
+                },
+                "end": {
+                    "line": 7,
+                    "character": 25
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_config/test_runtime_config_errors.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"validator\" in function \"__init__\"\n  Argument type is \"(cfg: Unknown) -> tuple[Literal[False], dict[str, str]]\"",
+            "range": {
+                "start": {
+                    "line": 23,
+                    "character": 36
+                },
+                "end": {
+                    "line": 23,
+                    "character": 53
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_config/test_settings.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_config/test_validate.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_evaluation/test_ragas_integration.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py",
+            "severity": "error",
+            "message": "\"_load_dashboard\" is private and used outside of the module in which it is declared",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 28
+                },
+                "end": {
+                    "line": 7,
+                    "character": 43
+                }
+            },
+            "rule": "reportPrivateUsage"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py",
+            "severity": "error",
+            "message": "Type of parameter \"start\" is unknown",
+            "range": {
+                "start": {
+                    "line": 74,
+                    "character": 26
+                },
+                "end": {
+                    "line": 74,
+                    "character": 31
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"start\"",
+            "range": {
+                "start": {
+                    "line": 74,
+                    "character": 26
+                },
+                "end": {
+                    "line": 74,
+                    "character": 31
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py",
+            "severity": "error",
+            "message": "Type of parameter \"end\" is unknown",
+            "range": {
+                "start": {
+                    "line": 74,
+                    "character": 33
+                },
+                "end": {
+                    "line": 74,
+                    "character": 36
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"end\"",
+            "range": {
+                "start": {
+                    "line": 74,
+                    "character": 33
+                },
+                "end": {
+                    "line": 74,
+                    "character": 36
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"value\" in function \"setattr\"\n  Argument type is \"(start: Unknown, end: Unknown) -> list[EvaluationResult]\"",
+            "range": {
+                "start": {
+                    "line": 77,
+                    "character": 51
+                },
+                "end": {
+                    "line": 77,
+                    "character": 68
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py",
+            "severity": "error",
+            "message": "Variable \"summary\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 78,
+                    "character": 4
+                },
+                "end": {
+                    "line": 78,
+                    "character": 11
+                }
+            },
+            "rule": "reportUnusedVariable"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py",
+            "severity": "error",
+            "message": "Variable \"fig\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 78,
+                    "character": 13
+                },
+                "end": {
+                    "line": 78,
+                    "character": 16
+                }
+            },
+            "rule": "reportUnusedVariable"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py",
+            "severity": "error",
+            "message": "Variable \"df\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 78,
+                    "character": 18
+                },
+                "end": {
+                    "line": 78,
+                    "character": 20
+                }
+            },
+            "rule": "reportUnusedVariable"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py",
+            "severity": "error",
+            "message": "Variable \"corr\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 78,
+                    "character": 22
+                },
+                "end": {
+                    "line": 78,
+                    "character": 26
+                }
+            },
+            "rule": "reportUnusedVariable"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py",
+            "severity": "error",
+            "message": "Variable \"alerts\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 78,
+                    "character": 28
+                },
+                "end": {
+                    "line": 78,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnusedVariable"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"vectors\" is unknown",
+            "range": {
+                "start": {
+                    "line": 23,
+                    "character": 21
+                },
+                "end": {
+                    "line": 23,
+                    "character": 28
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"vectors\"",
+            "range": {
+                "start": {
+                    "line": 23,
+                    "character": 21
+                },
+                "end": {
+                    "line": 23,
+                    "character": 28
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"namespace\" is partially unknown\n  Parameter type is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 23,
+                    "character": 30
+                },
+                "end": {
+                    "line": 23,
+                    "character": 39
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"namespace\"",
+            "range": {
+                "start": {
+                    "line": 23,
+                    "character": 30
+                },
+                "end": {
+                    "line": 23,
+                    "character": 39
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"object\" in function \"append\"",
+            "range": {
+                "start": {
+                    "line": 28,
+                    "character": 41
+                },
+                "end": {
+                    "line": 28,
+                    "character": 48
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Return type, \"dict[str, list[Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 8
+                },
+                "end": {
+                    "line": 30,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"vector\" is unknown",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 20
+                },
+                "end": {
+                    "line": 30,
+                    "character": 26
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"vector\"",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 20
+                },
+                "end": {
+                    "line": 30,
+                    "character": 26
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"top_k\" is unknown",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 28
+                },
+                "end": {
+                    "line": 30,
+                    "character": 33
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"top_k\"",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 28
+                },
+                "end": {
+                    "line": 30,
+                    "character": 33
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"include_metadata\" is unknown",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 35
+                },
+                "end": {
+                    "line": 30,
+                    "character": 51
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"include_metadata\"",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 35
+                },
+                "end": {
+                    "line": 30,
+                    "character": 51
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"namespace\" is partially unknown\n  Parameter type is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 53
+                },
+                "end": {
+                    "line": 30,
+                    "character": 62
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"namespace\"",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 53
+                },
+                "end": {
+                    "line": 30,
+                    "character": 62
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Return type, \"dict[str, list[Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 35,
+                    "character": 15
+                },
+                "end": {
+                    "line": 35,
+                    "character": 30
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"api_key\" is partially unknown\n  Parameter type is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 41,
+                    "character": 18
+                },
+                "end": {
+                    "line": 41,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"api_key\"",
+            "range": {
+                "start": {
+                    "line": 41,
+                    "character": 18
+                },
+                "end": {
+                    "line": 41,
+                    "character": 25
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"environment\" is partially unknown\n  Parameter type is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 41,
+                    "character": 32
+                },
+                "end": {
+                    "line": 41,
+                    "character": 43
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"environment\"",
+            "range": {
+                "start": {
+                    "line": 41,
+                    "character": 32
+                },
+                "end": {
+                    "line": 41,
+                    "character": 43
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Return type, \"list[Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 44,
+                    "character": 8
+                },
+                "end": {
+                    "line": 44,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Return type, \"list[Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 45,
+                    "character": 15
+                },
+                "end": {
+                    "line": 45,
+                    "character": 17
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 47,
+                    "character": 26
+                },
+                "end": {
+                    "line": 47,
+                    "character": 30
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"name\"",
+            "range": {
+                "start": {
+                    "line": 47,
+                    "character": 26
+                },
+                "end": {
+                    "line": 47,
+                    "character": 30
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"dimension\" is unknown",
+            "range": {
+                "start": {
+                    "line": 47,
+                    "character": 32
+                },
+                "end": {
+                    "line": 47,
+                    "character": 41
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"dimension\"",
+            "range": {
+                "start": {
+                    "line": 47,
+                    "character": 32
+                },
+                "end": {
+                    "line": 47,
+                    "character": 41
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"metric\" is unknown",
+            "range": {
+                "start": {
+                    "line": 47,
+                    "character": 43
+                },
+                "end": {
+                    "line": 47,
+                    "character": 49
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"metric\"",
+            "range": {
+                "start": {
+                    "line": 47,
+                    "character": 43
+                },
+                "end": {
+                    "line": 47,
+                    "character": 49
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 58,
+                    "character": 28
+                },
+                "end": {
+                    "line": 58,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 59,
+                    "character": 21
+                },
+                "end": {
+                    "line": 59,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 60,
+                    "character": 30
+                },
+                "end": {
+                    "line": 60,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 73,
+                    "character": 26
+                },
+                "end": {
+                    "line": 73,
+                    "character": 30
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"name\"",
+            "range": {
+                "start": {
+                    "line": 73,
+                    "character": 26
+                },
+                "end": {
+                    "line": 73,
+                    "character": 30
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"api_key\" is partially unknown",
+            "range": {
+                "start": {
+                    "line": 79,
+                    "character": 20
+                },
+                "end": {
+                    "line": 79,
+                    "character": 27
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"environment\" is partially unknown",
+            "range": {
+                "start": {
+                    "line": 79,
+                    "character": 34
+                },
+                "end": {
+                    "line": 79,
+                    "character": 45
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 82,
+                    "character": 21
+                },
+                "end": {
+                    "line": 82,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"kwargs\" is partially unknown",
+            "range": {
+                "start": {
+                    "line": 83,
+                    "character": 30
+                },
+                "end": {
+                    "line": 83,
+                    "character": 36
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 84,
+                    "character": 30
+                },
+                "end": {
+                    "line": 84,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"api_key\" is partially unknown",
+            "range": {
+                "start": {
+                    "line": 97,
+                    "character": 20
+                },
+                "end": {
+                    "line": 97,
+                    "character": 27
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"environment\" is partially unknown",
+            "range": {
+                "start": {
+                    "line": 97,
+                    "character": 34
+                },
+                "end": {
+                    "line": 97,
+                    "character": 45
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 98,
+                    "character": 21
+                },
+                "end": {
+                    "line": 98,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 99,
+                    "character": 30
+                },
+                "end": {
+                    "line": 99,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Return type of lambda, \"list[Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 100,
+                    "character": 29
+                },
+                "end": {
+                    "line": 100,
+                    "character": 31
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"kwargs\" is partially unknown",
+            "range": {
+                "start": {
+                    "line": 101,
+                    "character": 30
+                },
+                "end": {
+                    "line": 101,
+                    "character": 36
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 102,
+                    "character": 28
+                },
+                "end": {
+                    "line": 102,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"value\" in function \"setattr\"\n  Argument type is \"(s: Unknown) -> None\"",
+            "range": {
+                "start": {
+                    "line": 111,
+                    "character": 8
+                },
+                "end": {
+                    "line": 111,
+                    "character": 39
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"s\" is unknown",
+            "range": {
+                "start": {
+                    "line": 111,
+                    "character": 15
+                },
+                "end": {
+                    "line": 111,
+                    "character": 16
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"object\" in function \"append\"",
+            "range": {
+                "start": {
+                    "line": 111,
+                    "character": 37
+                },
+                "end": {
+                    "line": 111,
+                    "character": 38
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of \"vectors\" is partially unknown\n  Type of \"vectors\" is \"list[tuple[str, list[float], dict[Unknown, Unknown]]]\"",
+            "range": {
+                "start": {
+                    "line": 113,
+                    "character": 4
+                },
+                "end": {
+                    "line": 113,
+                    "character": 11
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"vectors\" in function \"upsert_embeddings\"\n  Argument type is \"list[tuple[str, list[float], dict[Unknown, Unknown]]]\"",
+            "range": {
+                "start": {
+                    "line": 116,
+                    "character": 8
+                },
+                "end": {
+                    "line": 116,
+                    "character": 15
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"api_key\" is partially unknown",
+            "range": {
+                "start": {
+                    "line": 129,
+                    "character": 20
+                },
+                "end": {
+                    "line": 129,
+                    "character": 27
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"environment\" is partially unknown",
+            "range": {
+                "start": {
+                    "line": 129,
+                    "character": 34
+                },
+                "end": {
+                    "line": 129,
+                    "character": 45
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 130,
+                    "character": 21
+                },
+                "end": {
+                    "line": 130,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 131,
+                    "character": 30
+                },
+                "end": {
+                    "line": 131,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Return type of lambda, \"list[Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 132,
+                    "character": 29
+                },
+                "end": {
+                    "line": 132,
+                    "character": 31
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"kwargs\" is partially unknown",
+            "range": {
+                "start": {
+                    "line": 133,
+                    "character": 30
+                },
+                "end": {
+                    "line": 133,
+                    "character": 36
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py",
+            "severity": "error",
+            "message": "Type of parameter \"name\" is unknown",
+            "range": {
+                "start": {
+                    "line": 134,
+                    "character": 28
+                },
+                "end": {
+                    "line": 134,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_monitoring/test_auto_tuner.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_monitoring/test_performance.py",
+            "severity": "error",
+            "message": "Type of \"approx\" is partially unknown\n  Type of \"approx\" is \"(expected: Unknown, rel: Unknown | None = None, abs: Unknown | None = None, nan_ok: bool = False) -> ApproxBase\"",
+            "range": {
+                "start": {
+                    "line": 65,
+                    "character": 45
+                },
+                "end": {
+                    "line": 65,
+                    "character": 58
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_monitoring/test_policy_management.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_monitoring/test_tracker_dashboard.py",
+            "severity": "error",
+            "message": "Type of \"approx\" is partially unknown\n  Type of \"approx\" is \"(expected: Unknown, rel: Unknown | None = None, abs: Unknown | None = None, nan_ok: bool = False) -> ApproxBase\"",
+            "range": {
+                "start": {
+                    "line": 38,
+                    "character": 32
+                },
+                "end": {
+                    "line": 38,
+                    "character": 45
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_monitoring/test_tracker_dashboard.py",
+            "severity": "error",
+            "message": "Type of \"approx\" is partially unknown\n  Type of \"approx\" is \"(expected: Unknown, rel: Unknown | None = None, abs: Unknown | None = None, nan_ok: bool = False) -> ApproxBase\"",
+            "range": {
+                "start": {
+                    "line": 39,
+                    "character": 31
+                },
+                "end": {
+                    "line": 39,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_monitoring/test_tracker_dashboard.py",
+            "severity": "error",
+            "message": "Type of \"approx\" is partially unknown\n  Type of \"approx\" is \"(expected: Unknown, rel: Unknown | None = None, abs: Unknown | None = None, nan_ok: bool = False) -> ApproxBase\"",
+            "range": {
+                "start": {
+                    "line": 40,
+                    "character": 45
+                },
+                "end": {
+                    "line": 40,
+                    "character": 58
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_query_service.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_query_service.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[Unknown], dict[Unknown, Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 10,
+                    "character": 8
+                },
+                "end": {
+                    "line": 10,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_query_service.py",
+            "severity": "error",
+            "message": "Type of parameter \"query\" is unknown",
+            "range": {
+                "start": {
+                    "line": 10,
+                    "character": 20
+                },
+                "end": {
+                    "line": 10,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_query_service.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"query\"",
+            "range": {
+                "start": {
+                    "line": 10,
+                    "character": 20
+                },
+                "end": {
+                    "line": 10,
+                    "character": 25
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_query_service.py",
+            "severity": "error",
+            "message": "Type of parameter \"mode\" is partially unknown\n  Parameter type is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 10,
+                    "character": 27
+                },
+                "end": {
+                    "line": 10,
+                    "character": 31
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_query_service.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"mode\"",
+            "range": {
+                "start": {
+                    "line": 10,
+                    "character": 27
+                },
+                "end": {
+                    "line": 10,
+                    "character": 31
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_query_service.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"top_k\"",
+            "range": {
+                "start": {
+                    "line": 10,
+                    "character": 38
+                },
+                "end": {
+                    "line": 10,
+                    "character": 43
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_query_service.py",
+            "severity": "error",
+            "message": "Type of parameter \"kwargs\" is unknown",
+            "range": {
+                "start": {
+                    "line": 10,
+                    "character": 49
+                },
+                "end": {
+                    "line": 10,
+                    "character": 55
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_query_service.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"kwargs\"",
+            "range": {
+                "start": {
+                    "line": 10,
+                    "character": 49
+                },
+                "end": {
+                    "line": 10,
+                    "character": 55
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_query_service.py",
+            "severity": "error",
+            "message": "Type of \"last_mode\" is partially unknown\n  Type of \"last_mode\" is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 11,
+                    "character": 8
+                },
+                "end": {
+                    "line": 11,
+                    "character": 22
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_query_service.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[Unknown], dict[Unknown, Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 12,
+                    "character": 15
+                },
+                "end": {
+                    "line": 12,
+                    "character": 21
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_query_service.py",
+            "severity": "error",
+            "message": "Argument of type \"StubHybrid\" cannot be assigned to parameter \"retriever\" of type \"HybridRetriever\" in function \"__init__\"\n  \"StubHybrid\" is not assignable to \"HybridRetriever\"",
+            "range": {
+                "start": {
+                    "line": 17,
+                    "character": 27
+                },
+                "end": {
+                    "line": 17,
+                    "character": 31
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_query_service.py",
+            "severity": "error",
+            "message": "Type of \"last_mode\" is partially unknown\n  Type of \"last_mode\" is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 19,
+                    "character": 11
+                },
+                "end": {
+                    "line": 19,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_query_service.py",
+            "severity": "error",
+            "message": "Argument of type \"StubHybrid\" cannot be assigned to parameter \"retriever\" of type \"HybridRetriever\" in function \"__init__\"\n  \"StubHybrid\" is not assignable to \"HybridRetriever\"",
+            "range": {
+                "start": {
+                    "line": 24,
+                    "character": 27
+                },
+                "end": {
+                    "line": 24,
+                    "character": 31
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_query_service.py",
+            "severity": "error",
+            "message": "Type of \"last_mode\" is partially unknown\n  Type of \"last_mode\" is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 26,
+                    "character": 11
+                },
+                "end": {
+                    "line": 26,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Return type, \"list[dict[str, Unknown | str]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 8,
+                    "character": 4
+                },
+                "end": {
+                    "line": 8,
+                    "character": 15
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type of parameter \"ids\" is unknown",
+            "range": {
+                "start": {
+                    "line": 8,
+                    "character": 16
+                },
+                "end": {
+                    "line": 8,
+                    "character": 19
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"ids\"",
+            "range": {
+                "start": {
+                    "line": 8,
+                    "character": 16
+                },
+                "end": {
+                    "line": 8,
+                    "character": 19
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Return type, \"list[dict[str, Unknown | str]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 9,
+                    "character": 11
+                },
+                "end": {
+                    "line": 9,
+                    "character": 56
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type of \"i\" is unknown",
+            "range": {
+                "start": {
+                    "line": 9,
+                    "character": 47
+                },
+                "end": {
+                    "line": 9,
+                    "character": 48
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type of parameter \"query\" is unknown",
+            "range": {
+                "start": {
+                    "line": 15,
+                    "character": 20
+                },
+                "end": {
+                    "line": 15,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"query\"",
+            "range": {
+                "start": {
+                    "line": 15,
+                    "character": 20
+                },
+                "end": {
+                    "line": 15,
+                    "character": 25
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type of parameter \"texts\" is unknown",
+            "range": {
+                "start": {
+                    "line": 15,
+                    "character": 27
+                },
+                "end": {
+                    "line": 15,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"texts\"",
+            "range": {
+                "start": {
+                    "line": 15,
+                    "character": 27
+                },
+                "end": {
+                    "line": 15,
+                    "character": 32
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type of parameter \"query\" is unknown",
+            "range": {
+                "start": {
+                    "line": 28,
+                    "character": 20
+                },
+                "end": {
+                    "line": 28,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"query\"",
+            "range": {
+                "start": {
+                    "line": 28,
+                    "character": 20
+                },
+                "end": {
+                    "line": 28,
+                    "character": 25
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type of parameter \"texts\" is unknown",
+            "range": {
+                "start": {
+                    "line": 28,
+                    "character": 27
+                },
+                "end": {
+                    "line": 28,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"texts\"",
+            "range": {
+                "start": {
+                    "line": 28,
+                    "character": 27
+                },
+                "end": {
+                    "line": 28,
+                    "character": 32
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type of \"_\" is unknown",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 24
+                },
+                "end": {
+                    "line": 30,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type of parameter \"benchmark\" is unknown",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 28
+                },
+                "end": {
+                    "line": 46,
+                    "character": 37
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"benchmark\"",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 28
+                },
+                "end": {
+                    "line": 46,
+                    "character": 37
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type of parameter \"q\" is unknown",
+            "range": {
+                "start": {
+                    "line": 49,
+                    "character": 20
+                },
+                "end": {
+                    "line": 49,
+                    "character": 21
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"q\"",
+            "range": {
+                "start": {
+                    "line": 49,
+                    "character": 20
+                },
+                "end": {
+                    "line": 49,
+                    "character": 21
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type of parameter \"texts\" is unknown",
+            "range": {
+                "start": {
+                    "line": 49,
+                    "character": 23
+                },
+                "end": {
+                    "line": 49,
+                    "character": 28
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"texts\"",
+            "range": {
+                "start": {
+                    "line": 49,
+                    "character": 23
+                },
+                "end": {
+                    "line": 49,
+                    "character": 28
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py",
+            "severity": "error",
+            "message": "Type of \"_\" is unknown",
+            "range": {
+                "start": {
+                    "line": 50,
+                    "character": 24
+                },
+                "end": {
+                    "line": 50,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ranking/test_rrf.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/conftest.py",
+            "severity": "error",
+            "message": "Type of parameter \"args\" is unknown",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 24
+                },
+                "end": {
+                    "line": 7,
+                    "character": 28
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/conftest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"args\"",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 24
+                },
+                "end": {
+                    "line": 7,
+                    "character": 28
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/conftest.py",
+            "severity": "error",
+            "message": "Type of parameter \"kwargs\" is unknown",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 32
+                },
+                "end": {
+                    "line": 7,
+                    "character": 38
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/conftest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"kwargs\"",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 32
+                },
+                "end": {
+                    "line": 7,
+                    "character": 38
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/conftest.py",
+            "severity": "error",
+            "message": "Return type, \"list[Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 11,
+                    "character": 4
+                },
+                "end": {
+                    "line": 11,
+                    "character": 10
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/conftest.py",
+            "severity": "error",
+            "message": "Type of parameter \"self\" is unknown",
+            "range": {
+                "start": {
+                    "line": 11,
+                    "character": 11
+                },
+                "end": {
+                    "line": 11,
+                    "character": 15
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/conftest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"self\"",
+            "range": {
+                "start": {
+                    "line": 11,
+                    "character": 11
+                },
+                "end": {
+                    "line": 11,
+                    "character": 15
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/conftest.py",
+            "severity": "error",
+            "message": "Type of parameter \"args\" is unknown",
+            "range": {
+                "start": {
+                    "line": 11,
+                    "character": 18
+                },
+                "end": {
+                    "line": 11,
+                    "character": 22
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/conftest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"args\"",
+            "range": {
+                "start": {
+                    "line": 11,
+                    "character": 18
+                },
+                "end": {
+                    "line": 11,
+                    "character": 22
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/conftest.py",
+            "severity": "error",
+            "message": "Type of parameter \"kwargs\" is unknown",
+            "range": {
+                "start": {
+                    "line": 11,
+                    "character": 26
+                },
+                "end": {
+                    "line": 11,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/conftest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"kwargs\"",
+            "range": {
+                "start": {
+                    "line": 11,
+                    "character": 26
+                },
+                "end": {
+                    "line": 11,
+                    "character": 32
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/conftest.py",
+            "severity": "error",
+            "message": "Return type, \"list[Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 12,
+                    "character": 11
+                },
+                "end": {
+                    "line": 12,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/conftest.py",
+            "severity": "error",
+            "message": "Cannot assign to attribute \"encode\" for class \"type[SentenceTransformer]\"\n  Attribute \"encode\" is unknown",
+            "range": {
+                "start": {
+                    "line": 15,
+                    "character": 20
+                },
+                "end": {
+                    "line": 15,
+                    "character": 26
+                }
+            },
+            "rule": "reportAttributeAccessIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/conftest.py",
+            "severity": "error",
+            "message": "Cannot assign to attribute \"SentenceTransformer\" for class \"ModuleType\"\n  Attribute \"SentenceTransformer\" is unknown",
+            "range": {
+                "start": {
+                    "line": 16,
+                    "character": 5
+                },
+                "end": {
+                    "line": 16,
+                    "character": 24
+                }
+            },
+            "rule": "reportAttributeAccessIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type of parameter \"vectors\" is unknown",
+            "range": {
+                "start": {
+                    "line": 19,
+                    "character": 49
+                },
+                "end": {
+                    "line": 19,
+                    "character": 56
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"vectors\"",
+            "range": {
+                "start": {
+                    "line": 19,
+                    "character": 49
+                },
+                "end": {
+                    "line": 19,
+                    "character": 56
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type of \"vectors\" is partially unknown\n  Type of \"vectors\" is \"list[Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 20,
+                    "character": 8
+                },
+                "end": {
+                    "line": 20,
+                    "character": 20
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type of \"extend\" is partially unknown\n  Type of \"extend\" is \"(iterable: Iterable[Unknown], /) -> None\"",
+            "range": {
+                "start": {
+                    "line": 20,
+                    "character": 8
+                },
+                "end": {
+                    "line": 20,
+                    "character": 27
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"iterable\" in function \"extend\"",
+            "range": {
+                "start": {
+                    "line": 20,
+                    "character": 28
+                },
+                "end": {
+                    "line": 20,
+                    "character": 35
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type of parameter \"mock_model\" is unknown",
+            "range": {
+                "start": {
+                    "line": 24,
+                    "character": 39
+                },
+                "end": {
+                    "line": 24,
+                    "character": 49
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"mock_model\"",
+            "range": {
+                "start": {
+                    "line": 24,
+                    "character": 39
+                },
+                "end": {
+                    "line": 24,
+                    "character": 49
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Argument of type \"MockPineconeClient\" cannot be assigned to parameter \"pinecone_client\" of type \"PineconeClient\" in function \"__init__\"\n  \"MockPineconeClient\" is not assignable to \"PineconeClient\"",
+            "range": {
+                "start": {
+                    "line": 32,
+                    "character": 31
+                },
+                "end": {
+                    "line": 32,
+                    "character": 37
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type of parameter \"mock_model\" is unknown",
+            "range": {
+                "start": {
+                    "line": 39,
+                    "character": 38
+                },
+                "end": {
+                    "line": 39,
+                    "character": 48
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"mock_model\"",
+            "range": {
+                "start": {
+                    "line": 39,
+                    "character": 38
+                },
+                "end": {
+                    "line": 39,
+                    "character": 48
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type of parameter \"texts\" is unknown",
+            "range": {
+                "start": {
+                    "line": 44,
+                    "character": 18
+                },
+                "end": {
+                    "line": 44,
+                    "character": 23
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"texts\"",
+            "range": {
+                "start": {
+                    "line": 44,
+                    "character": 18
+                },
+                "end": {
+                    "line": 44,
+                    "character": 23
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type of parameter \"batch_size\" is unknown",
+            "range": {
+                "start": {
+                    "line": 44,
+                    "character": 25
+                },
+                "end": {
+                    "line": 44,
+                    "character": 35
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"batch_size\"",
+            "range": {
+                "start": {
+                    "line": 44,
+                    "character": 25
+                },
+                "end": {
+                    "line": 44,
+                    "character": 35
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type of parameter \"show_progress_bar\" is unknown",
+            "range": {
+                "start": {
+                    "line": 44,
+                    "character": 37
+                },
+                "end": {
+                    "line": 44,
+                    "character": 54
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"show_progress_bar\"",
+            "range": {
+                "start": {
+                    "line": 44,
+                    "character": 37
+                },
+                "end": {
+                    "line": 44,
+                    "character": 54
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"obj\" in function \"len\"",
+            "range": {
+                "start": {
+                    "line": 45,
+                    "character": 29
+                },
+                "end": {
+                    "line": 45,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Argument of type \"MockPineconeClient\" cannot be assigned to parameter \"pinecone_client\" of type \"PineconeClient\" in function \"__init__\"\n  \"MockPineconeClient\" is not assignable to \"PineconeClient\"",
+            "range": {
+                "start": {
+                    "line": 51,
+                    "character": 31
+                },
+                "end": {
+                    "line": 51,
+                    "character": 37
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type of \"vectors\" is partially unknown\n  Type of \"vectors\" is \"list[Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 57,
+                    "character": 15
+                },
+                "end": {
+                    "line": 57,
+                    "character": 29
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"obj\" in function \"len\"\n  Argument type is \"list[Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 57,
+                    "character": 15
+                },
+                "end": {
+                    "line": 57,
+                    "character": 29
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type of parameter \"mock_model\" is unknown",
+            "range": {
+                "start": {
+                    "line": 61,
+                    "character": 37
+                },
+                "end": {
+                    "line": 61,
+                    "character": 47
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"mock_model\"",
+            "range": {
+                "start": {
+                    "line": 61,
+                    "character": 37
+                },
+                "end": {
+                    "line": 61,
+                    "character": 47
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Argument of type \"MockPineconeClient\" cannot be assigned to parameter \"pinecone_client\" of type \"PineconeClient\" in function \"__init__\"\n  \"MockPineconeClient\" is not assignable to \"PineconeClient\"",
+            "range": {
+                "start": {
+                    "line": 67,
+                    "character": 31
+                },
+                "end": {
+                    "line": 67,
+                    "character": 37
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Type of \"assert_called_with\" is unknown",
+            "range": {
+                "start": {
+                    "line": 69,
+                    "character": 4
+                },
+                "end": {
+                    "line": 69,
+                    "character": 33
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py",
+            "severity": "error",
+            "message": "Argument of type \"MockPineconeClient\" cannot be assigned to parameter \"pinecone_client\" of type \"PineconeClient\" in function \"__init__\"\n  \"MockPineconeClient\" is not assignable to \"PineconeClient\"",
+            "range": {
+                "start": {
+                    "line": 87,
+                    "character": 35
+                },
+                "end": {
+                    "line": 87,
+                    "character": 41
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py",
+            "severity": "error",
+            "message": "Type of parameter \"query\" is unknown",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 20
+                },
+                "end": {
+                    "line": 7,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"query\"",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 20
+                },
+                "end": {
+                    "line": 7,
+                    "character": 25
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"top_k\"",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 27
+                },
+                "end": {
+                    "line": 7,
+                    "character": 32
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py",
+            "severity": "error",
+            "message": "Type of parameter \"query\" is unknown",
+            "range": {
+                "start": {
+                    "line": 12,
+                    "character": 20
+                },
+                "end": {
+                    "line": 12,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"query\"",
+            "range": {
+                "start": {
+                    "line": 12,
+                    "character": 20
+                },
+                "end": {
+                    "line": 12,
+                    "character": 25
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"top_k\"",
+            "range": {
+                "start": {
+                    "line": 12,
+                    "character": 27
+                },
+                "end": {
+                    "line": 12,
+                    "character": 32
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py",
+            "severity": "error",
+            "message": "Argument of type \"StubDense\" cannot be assigned to parameter \"dense_retriever\" of type \"DenseRetriever\" in function \"__init__\"\n  \"StubDense\" is not assignable to \"DenseRetriever\"",
+            "range": {
+                "start": {
+                    "line": 17,
+                    "character": 29
+                },
+                "end": {
+                    "line": 17,
+                    "character": 40
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py",
+            "severity": "error",
+            "message": "Argument of type \"StubLexical\" cannot be assigned to parameter \"lexical_retriever\" of type \"LexicalBM25\" in function \"__init__\"\n  \"StubLexical\" is not assignable to \"LexicalBM25\"",
+            "range": {
+                "start": {
+                    "line": 17,
+                    "character": 42
+                },
+                "end": {
+                    "line": 17,
+                    "character": 55
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py",
+            "severity": "error",
+            "message": "Argument of type \"StubDense\" cannot be assigned to parameter \"dense_retriever\" of type \"DenseRetriever\" in function \"__init__\"\n  \"StubDense\" is not assignable to \"DenseRetriever\"",
+            "range": {
+                "start": {
+                    "line": 27,
+                    "character": 29
+                },
+                "end": {
+                    "line": 27,
+                    "character": 40
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py",
+            "severity": "error",
+            "message": "Argument of type \"StubLexical\" cannot be assigned to parameter \"lexical_retriever\" of type \"LexicalBM25\" in function \"__init__\"\n  \"StubLexical\" is not assignable to \"LexicalBM25\"",
+            "range": {
+                "start": {
+                    "line": 27,
+                    "character": 42
+                },
+                "end": {
+                    "line": 27,
+                    "character": 55
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py",
+            "severity": "error",
+            "message": "Argument of type \"StubDense\" cannot be assigned to parameter \"dense_retriever\" of type \"DenseRetriever\" in function \"__init__\"\n  \"StubDense\" is not assignable to \"DenseRetriever\"",
+            "range": {
+                "start": {
+                    "line": 39,
+                    "character": 27
+                },
+                "end": {
+                    "line": 39,
+                    "character": 38
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[tuple[str, float]], dict[Unknown, Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 8
+                },
+                "end": {
+                    "line": 7,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Type of parameter \"query\" is unknown",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 20
+                },
+                "end": {
+                    "line": 7,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"query\"",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 20
+                },
+                "end": {
+                    "line": 7,
+                    "character": 25
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"top_k\"",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 27
+                },
+                "end": {
+                    "line": 7,
+                    "character": 32
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[tuple[str, float]], dict[Unknown, Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 8,
+                    "character": 15
+                },
+                "end": {
+                    "line": 8,
+                    "character": 43
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[tuple[str, float]], dict[Unknown, Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 16,
+                    "character": 8
+                },
+                "end": {
+                    "line": 16,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Type of parameter \"query\" is unknown",
+            "range": {
+                "start": {
+                    "line": 16,
+                    "character": 20
+                },
+                "end": {
+                    "line": 16,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"query\"",
+            "range": {
+                "start": {
+                    "line": 16,
+                    "character": 20
+                },
+                "end": {
+                    "line": 16,
+                    "character": 25
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"top_k\"",
+            "range": {
+                "start": {
+                    "line": 16,
+                    "character": 27
+                },
+                "end": {
+                    "line": 16,
+                    "character": 32
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[tuple[str, float]], dict[Unknown, Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 17,
+                    "character": 15
+                },
+                "end": {
+                    "line": 17,
+                    "character": 43
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[Unknown], dict[str, bool | int]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 21,
+                    "character": 8
+                },
+                "end": {
+                    "line": 21,
+                    "character": 14
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Type of parameter \"query\" is unknown",
+            "range": {
+                "start": {
+                    "line": 21,
+                    "character": 21
+                },
+                "end": {
+                    "line": 21,
+                    "character": 26
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"query\"",
+            "range": {
+                "start": {
+                    "line": 21,
+                    "character": 21
+                },
+                "end": {
+                    "line": 21,
+                    "character": 26
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Type of parameter \"docs\" is unknown",
+            "range": {
+                "start": {
+                    "line": 21,
+                    "character": 28
+                },
+                "end": {
+                    "line": 21,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"docs\"",
+            "range": {
+                "start": {
+                    "line": 21,
+                    "character": 28
+                },
+                "end": {
+                    "line": 21,
+                    "character": 32
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"top_k\"",
+            "range": {
+                "start": {
+                    "line": 21,
+                    "character": 34
+                },
+                "end": {
+                    "line": 21,
+                    "character": 39
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"session_id\"",
+            "range": {
+                "start": {
+                    "line": 21,
+                    "character": 43
+                },
+                "end": {
+                    "line": 21,
+                    "character": 53
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"timeout\"",
+            "range": {
+                "start": {
+                    "line": 21,
+                    "character": 65
+                },
+                "end": {
+                    "line": 21,
+                    "character": 72
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Type of \"docs\" is partially unknown\n  Type of \"docs\" is \"list[Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 22,
+                    "character": 8
+                },
+                "end": {
+                    "line": 22,
+                    "character": 12
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"iterable\" in function \"__init__\"\n  Argument type is \"Iterator[Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 22,
+                    "character": 20
+                },
+                "end": {
+                    "line": 22,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"sequence\" in function \"__new__\"",
+            "range": {
+                "start": {
+                    "line": 22,
+                    "character": 29
+                },
+                "end": {
+                    "line": 22,
+                    "character": 33
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Return type, \"tuple[list[Unknown], dict[str, bool | int]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 23,
+                    "character": 15
+                },
+                "end": {
+                    "line": 23,
+                    "character": 64
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Argument of type \"StubDense\" cannot be assigned to parameter \"dense_retriever\" of type \"DenseRetriever\" in function \"__init__\"\n  \"StubDense\" is not assignable to \"DenseRetriever\"",
+            "range": {
+                "start": {
+                    "line": 28,
+                    "character": 8
+                },
+                "end": {
+                    "line": 28,
+                    "character": 19
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Argument of type \"StubLexical\" cannot be assigned to parameter \"lexical_retriever\" of type \"LexicalBM25\" in function \"__init__\"\n  \"StubLexical\" is not assignable to \"LexicalBM25\"",
+            "range": {
+                "start": {
+                    "line": 29,
+                    "character": 8
+                },
+                "end": {
+                    "line": 29,
+                    "character": 21
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py",
+            "severity": "error",
+            "message": "Argument of type \"StubReranker\" cannot be assigned to parameter \"reranker\" of type \"CrossEncoderReranker | None\" in function \"__init__\"\n  Type \"StubReranker\" is not assignable to type \"CrossEncoderReranker | None\"\n    \"StubReranker\" is not assignable to \"CrossEncoderReranker\"\n    \"StubReranker\" is not assignable to \"None\"",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 17
+                },
+                "end": {
+                    "line": 30,
+                    "character": 31
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_lexical.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_query_analysis.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_query_analysis.py",
+            "severity": "error",
+            "message": "Argument of type \"DummyLexical\" cannot be assigned to parameter \"lexical\" of type \"LexicalBM25\" in function \"analyze_query\"\n  \"DummyLexical\" is not assignable to \"LexicalBM25\"",
+            "range": {
+                "start": {
+                    "line": 15,
+                    "character": 49
+                },
+                "end": {
+                    "line": 15,
+                    "character": 56
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_retrieval/test_query_analysis.py",
+            "severity": "error",
+            "message": "Argument of type \"DummyLexical\" cannot be assigned to parameter \"lexical\" of type \"LexicalBM25\" in function \"analyze_query\"\n  \"DummyLexical\" is not assignable to \"LexicalBM25\"",
+            "range": {
+                "start": {
+                    "line": 23,
+                    "character": 45
+                },
+                "end": {
+                    "line": 23,
+                    "character": 52
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "warning",
+            "message": "Import \"fpdf\" could not be resolved from source",
+            "range": {
+                "start": {
+                    "line": 32,
+                    "character": 9
+                },
+                "end": {
+                    "line": 32,
+                    "character": 13
+                }
+            },
+            "rule": "reportMissingModuleSource"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "No parameter named \"txt\"",
+            "range": {
+                "start": {
+                    "line": 37,
+                    "character": 22
+                },
+                "end": {
+                    "line": 37,
+                    "character": 25
+                }
+            },
+            "rule": "reportCallIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "No overloads for \"output\" match the provided arguments",
+            "range": {
+                "start": {
+                    "line": 38,
+                    "character": 4
+                },
+                "end": {
+                    "line": 38,
+                    "character": 20
+                }
+            },
+            "rule": "reportCallIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Argument of type \"Path\" cannot be assigned to parameter \"name\" of type \"str\" in function \"output\"\n  \"Path\" is not assignable to \"str\"",
+            "range": {
+                "start": {
+                    "line": 38,
+                    "character": 15
+                },
+                "end": {
+                    "line": 38,
+                    "character": 19
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Argument of type \"Path\" cannot be assigned to parameter \"path_or_stream\" of type \"str | IO[bytes]\" in function \"save\"\n  Type \"Path\" is not assignable to type \"str | IO[bytes]\"\n    \"Path\" is not assignable to \"str\"\n    \"Path\" is not assignable to \"IO[bytes]\"",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 13
+                },
+                "end": {
+                    "line": 46,
+                    "character": 17
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of parameter \"mocks\" is unknown",
+            "range": {
+                "start": {
+                    "line": 49,
+                    "character": 47
+                },
+                "end": {
+                    "line": 49,
+                    "character": 52
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"mocks\"",
+            "range": {
+                "start": {
+                    "line": 49,
+                    "character": 47
+                },
+                "end": {
+                    "line": 49,
+                    "character": 52
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"dense\" is unknown",
+            "range": {
+                "start": {
+                    "line": 50,
+                    "character": 4
+                },
+                "end": {
+                    "line": 50,
+                    "character": 9
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"lexical\" is unknown",
+            "range": {
+                "start": {
+                    "line": 50,
+                    "character": 11
+                },
+                "end": {
+                    "line": 50,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"dense_retriever\" in function \"__init__\"",
+            "range": {
+                "start": {
+                    "line": 51,
+                    "character": 30
+                },
+                "end": {
+                    "line": 51,
+                    "character": 35
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"lexical_retriever\" in function \"__init__\"",
+            "range": {
+                "start": {
+                    "line": 51,
+                    "character": 37
+                },
+                "end": {
+                    "line": 51,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of parameter \"mocks\" is unknown",
+            "range": {
+                "start": {
+                    "line": 77,
+                    "character": 42
+                },
+                "end": {
+                    "line": 77,
+                    "character": 47
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"mocks\"",
+            "range": {
+                "start": {
+                    "line": 77,
+                    "character": 42
+                },
+                "end": {
+                    "line": 77,
+                    "character": 47
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"dense\" is unknown",
+            "range": {
+                "start": {
+                    "line": 78,
+                    "character": 4
+                },
+                "end": {
+                    "line": 78,
+                    "character": 9
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"lexical\" is unknown",
+            "range": {
+                "start": {
+                    "line": 78,
+                    "character": 11
+                },
+                "end": {
+                    "line": 78,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"dense_retriever\" in function \"__init__\"",
+            "range": {
+                "start": {
+                    "line": 79,
+                    "character": 30
+                },
+                "end": {
+                    "line": 79,
+                    "character": 35
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"lexical_retriever\" in function \"__init__\"",
+            "range": {
+                "start": {
+                    "line": 79,
+                    "character": 37
+                },
+                "end": {
+                    "line": 79,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"index_corpus\" is unknown",
+            "range": {
+                "start": {
+                    "line": 85,
+                    "character": 11
+                },
+                "end": {
+                    "line": 85,
+                    "character": 29
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"call_args\" is unknown",
+            "range": {
+                "start": {
+                    "line": 85,
+                    "character": 11
+                },
+                "end": {
+                    "line": 85,
+                    "character": 39
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"index_documents\" is unknown",
+            "range": {
+                "start": {
+                    "line": 86,
+                    "character": 11
+                },
+                "end": {
+                    "line": 86,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"call_args\" is unknown",
+            "range": {
+                "start": {
+                    "line": 86,
+                    "character": 11
+                },
+                "end": {
+                    "line": 86,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of parameter \"mocks\" is unknown",
+            "range": {
+                "start": {
+                    "line": 92,
+                    "character": 50
+                },
+                "end": {
+                    "line": 92,
+                    "character": 55
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"mocks\"",
+            "range": {
+                "start": {
+                    "line": 92,
+                    "character": 50
+                },
+                "end": {
+                    "line": 92,
+                    "character": 55
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"dense\" is unknown",
+            "range": {
+                "start": {
+                    "line": 93,
+                    "character": 4
+                },
+                "end": {
+                    "line": 93,
+                    "character": 9
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"lexical\" is unknown",
+            "range": {
+                "start": {
+                    "line": 93,
+                    "character": 11
+                },
+                "end": {
+                    "line": 93,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"dense_retriever\" in function \"__init__\"",
+            "range": {
+                "start": {
+                    "line": 94,
+                    "character": 30
+                },
+                "end": {
+                    "line": 94,
+                    "character": 35
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"lexical_retriever\" in function \"__init__\"",
+            "range": {
+                "start": {
+                    "line": 94,
+                    "character": 37
+                },
+                "end": {
+                    "line": 94,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of parameter \"mocks\" is unknown",
+            "range": {
+                "start": {
+                    "line": 108,
+                    "character": 33
+                },
+                "end": {
+                    "line": 108,
+                    "character": 38
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"mocks\"",
+            "range": {
+                "start": {
+                    "line": 108,
+                    "character": 33
+                },
+                "end": {
+                    "line": 108,
+                    "character": 38
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"dense\" is unknown",
+            "range": {
+                "start": {
+                    "line": 109,
+                    "character": 4
+                },
+                "end": {
+                    "line": 109,
+                    "character": 9
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"lexical\" is unknown",
+            "range": {
+                "start": {
+                    "line": 109,
+                    "character": 11
+                },
+                "end": {
+                    "line": 109,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"dense_retriever\" in function \"__init__\"",
+            "range": {
+                "start": {
+                    "line": 110,
+                    "character": 30
+                },
+                "end": {
+                    "line": 110,
+                    "character": 35
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"lexical_retriever\" in function \"__init__\"",
+            "range": {
+                "start": {
+                    "line": 110,
+                    "character": 37
+                },
+                "end": {
+                    "line": 110,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"update_document\" is unknown",
+            "range": {
+                "start": {
+                    "line": 115,
+                    "character": 4
+                },
+                "end": {
+                    "line": 115,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"assert_called_with\" is unknown",
+            "range": {
+                "start": {
+                    "line": 115,
+                    "character": 4
+                },
+                "end": {
+                    "line": 115,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"update_document\" is unknown",
+            "range": {
+                "start": {
+                    "line": 116,
+                    "character": 4
+                },
+                "end": {
+                    "line": 116,
+                    "character": 27
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"assert_called_with\" is unknown",
+            "range": {
+                "start": {
+                    "line": 116,
+                    "character": 4
+                },
+                "end": {
+                    "line": 116,
+                    "character": 46
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"delete_document\" is unknown",
+            "range": {
+                "start": {
+                    "line": 117,
+                    "character": 4
+                },
+                "end": {
+                    "line": 117,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"assert_called_with\" is unknown",
+            "range": {
+                "start": {
+                    "line": 117,
+                    "character": 4
+                },
+                "end": {
+                    "line": 117,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"delete_document\" is unknown",
+            "range": {
+                "start": {
+                    "line": 118,
+                    "character": 4
+                },
+                "end": {
+                    "line": 118,
+                    "character": 27
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"assert_called_with\" is unknown",
+            "range": {
+                "start": {
+                    "line": 118,
+                    "character": 4
+                },
+                "end": {
+                    "line": 118,
+                    "character": 46
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of parameter \"mocks\" is unknown",
+            "range": {
+                "start": {
+                    "line": 124,
+                    "character": 31
+                },
+                "end": {
+                    "line": 124,
+                    "character": 36
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"mocks\"",
+            "range": {
+                "start": {
+                    "line": 124,
+                    "character": 31
+                },
+                "end": {
+                    "line": 124,
+                    "character": 36
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"dense\" is unknown",
+            "range": {
+                "start": {
+                    "line": 125,
+                    "character": 4
+                },
+                "end": {
+                    "line": 125,
+                    "character": 9
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"lexical\" is unknown",
+            "range": {
+                "start": {
+                    "line": 125,
+                    "character": 11
+                },
+                "end": {
+                    "line": 125,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"dense_retriever\" in function \"__init__\"",
+            "range": {
+                "start": {
+                    "line": 126,
+                    "character": 30
+                },
+                "end": {
+                    "line": 126,
+                    "character": 35
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"lexical_retriever\" in function \"__init__\"",
+            "range": {
+                "start": {
+                    "line": 126,
+                    "character": 37
+                },
+                "end": {
+                    "line": 126,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"update_document\" is unknown",
+            "range": {
+                "start": {
+                    "line": 134,
+                    "character": 4
+                },
+                "end": {
+                    "line": 134,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"assert_called_with\" is unknown",
+            "range": {
+                "start": {
+                    "line": 134,
+                    "character": 4
+                },
+                "end": {
+                    "line": 134,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"update_document\" is unknown",
+            "range": {
+                "start": {
+                    "line": 135,
+                    "character": 4
+                },
+                "end": {
+                    "line": 135,
+                    "character": 27
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"assert_called_with\" is unknown",
+            "range": {
+                "start": {
+                    "line": 135,
+                    "character": 4
+                },
+                "end": {
+                    "line": 135,
+                    "character": 46
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"delete_document\" is unknown",
+            "range": {
+                "start": {
+                    "line": 136,
+                    "character": 4
+                },
+                "end": {
+                    "line": 136,
+                    "character": 25
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"assert_called_with\" is unknown",
+            "range": {
+                "start": {
+                    "line": 136,
+                    "character": 4
+                },
+                "end": {
+                    "line": 136,
+                    "character": 44
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"delete_document\" is unknown",
+            "range": {
+                "start": {
+                    "line": 137,
+                    "character": 4
+                },
+                "end": {
+                    "line": 137,
+                    "character": 27
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_document_service.py",
+            "severity": "error",
+            "message": "Type of \"assert_called_with\" is unknown",
+            "range": {
+                "start": {
+                    "line": 137,
+                    "character": 4
+                },
+                "end": {
+                    "line": 137,
+                    "character": 46
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_index_management.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_index_management.py",
+            "severity": "error",
+            "message": "Argument of type \"DummyDense\" cannot be assigned to parameter \"dense\" of type \"DenseRetriever\" in function \"__init__\"\n  \"DummyDense\" is not assignable to \"DenseRetriever\"",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 27
+                },
+                "end": {
+                    "line": 46,
+                    "character": 39
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_services/test_index_management.py",
+            "severity": "error",
+            "message": "Argument of type \"DummyLexical\" cannot be assigned to parameter \"lexical\" of type \"LexicalBM25\" in function \"__init__\"\n  \"DummyLexical\" is not assignable to \"LexicalBM25\"",
+            "range": {
+                "start": {
+                    "line": 46,
+                    "character": 41
+                },
+                "end": {
+                    "line": 46,
+                    "character": 55
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_chat.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_chat.py",
+            "severity": "error",
+            "message": "\"_append_history\" is private and used outside of the module in which it is declared",
+            "range": {
+                "start": {
+                    "line": 9,
+                    "character": 4
+                },
+                "end": {
+                    "line": 9,
+                    "character": 19
+                }
+            },
+            "rule": "reportPrivateUsage"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_chat.py",
+            "severity": "error",
+            "message": "\"_generate_response\" is private and used outside of the module in which it is declared",
+            "range": {
+                "start": {
+                    "line": 10,
+                    "character": 4
+                },
+                "end": {
+                    "line": 10,
+                    "character": 22
+                }
+            },
+            "rule": "reportPrivateUsage"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_chat.py",
+            "severity": "error",
+            "message": "\"_sanitize\" is private and used outside of the module in which it is declared",
+            "range": {
+                "start": {
+                    "line": 11,
+                    "character": 4
+                },
+                "end": {
+                    "line": 11,
+                    "character": 13
+                }
+            },
+            "rule": "reportPrivateUsage"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_chat.py",
+            "severity": "error",
+            "message": "\"chat\" is possibly unbound",
+            "range": {
+                "start": {
+                    "line": 40,
+                    "character": 8
+                },
+                "end": {
+                    "line": 40,
+                    "character": 12
+                }
+            },
+            "rule": "reportPossiblyUnboundVariable"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_chat.py",
+            "severity": "error",
+            "message": "Cannot assign to attribute \"evaluate\" for class \"RagasEvaluator\"\n  Type \"(*_: Unknown, **__: Unknown) -> None\" is not assignable to type \"(query: str, answer: str, contexts: List[str]) -> EvaluationResult\"\n    Function return type \"None\" is incompatible with type \"EvaluationResult\"\n      \"None\" is not assignable to \"EvaluationResult\"",
+            "range": {
+                "start": {
+                    "line": 51,
+                    "character": 30
+                },
+                "end": {
+                    "line": 51,
+                    "character": 51
+                }
+            },
+            "rule": "reportAttributeAccessIssue"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_chat.py",
+            "severity": "error",
+            "message": "Type of parameter \"_\" is partially unknown",
+            "range": {
+                "start": {
+                    "line": 51,
+                    "character": 38
+                },
+                "end": {
+                    "line": 51,
+                    "character": 39
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_chat.py",
+            "severity": "error",
+            "message": "Type of parameter \"__\" is partially unknown",
+            "range": {
+                "start": {
+                    "line": 51,
+                    "character": 43
+                },
+                "end": {
+                    "line": 51,
+                    "character": 45
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_chat.py",
+            "severity": "error",
+            "message": "Type of parameter \"query\" is unknown",
+            "range": {
+                "start": {
+                    "line": 54,
+                    "character": 24
+                },
+                "end": {
+                    "line": 54,
+                    "character": 29
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_chat.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"query\"",
+            "range": {
+                "start": {
+                    "line": 54,
+                    "character": 24
+                },
+                "end": {
+                    "line": 54,
+                    "character": 29
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_chat.py",
+            "severity": "error",
+            "message": "Type of parameter \"mode\" is partially unknown\n  Parameter type is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 54,
+                    "character": 31
+                },
+                "end": {
+                    "line": 54,
+                    "character": 35
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_chat.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"mode\"",
+            "range": {
+                "start": {
+                    "line": 54,
+                    "character": 31
+                },
+                "end": {
+                    "line": 54,
+                    "character": 35
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_chat.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"top_k\"",
+            "range": {
+                "start": {
+                    "line": 54,
+                    "character": 42
+                },
+                "end": {
+                    "line": 54,
+                    "character": 47
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py",
+            "severity": "error",
+            "message": "\"_load_dashboard\" is private and used outside of the module in which it is declared",
+            "range": {
+                "start": {
+                    "line": 9,
+                    "character": 39
+                },
+                "end": {
+                    "line": 9,
+                    "character": 54
+                }
+            },
+            "rule": "reportPrivateUsage"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py",
+            "severity": "error",
+            "message": "Type of parameter \"start\" is unknown",
+            "range": {
+                "start": {
+                    "line": 60,
+                    "character": 18
+                },
+                "end": {
+                    "line": 60,
+                    "character": 23
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"start\"",
+            "range": {
+                "start": {
+                    "line": 60,
+                    "character": 18
+                },
+                "end": {
+                    "line": 60,
+                    "character": 23
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py",
+            "severity": "error",
+            "message": "Type of parameter \"end\" is unknown",
+            "range": {
+                "start": {
+                    "line": 60,
+                    "character": 25
+                },
+                "end": {
+                    "line": 60,
+                    "character": 28
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"end\"",
+            "range": {
+                "start": {
+                    "line": 60,
+                    "character": 25
+                },
+                "end": {
+                    "line": 60,
+                    "character": 28
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"value\" in function \"setattr\"\n  Argument type is \"(start: Unknown, end: Unknown) -> list[EvaluationResult]\"",
+            "range": {
+                "start": {
+                    "line": 65,
+                    "character": 51
+                },
+                "end": {
+                    "line": 65,
+                    "character": 60
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"value\" in function \"setattr\"\n  Argument type is \"(s: Unknown, e: Unknown) -> list[EvaluationResult]\"",
+            "range": {
+                "start": {
+                    "line": 114,
+                    "character": 51
+                },
+                "end": {
+                    "line": 114,
+                    "character": 71
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py",
+            "severity": "error",
+            "message": "Type of parameter \"s\" is unknown",
+            "range": {
+                "start": {
+                    "line": 114,
+                    "character": 58
+                },
+                "end": {
+                    "line": 114,
+                    "character": 59
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py",
+            "severity": "error",
+            "message": "Type of parameter \"e\" is unknown",
+            "range": {
+                "start": {
+                    "line": 114,
+                    "character": 61
+                },
+                "end": {
+                    "line": 114,
+                    "character": 62
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py",
+            "severity": "error",
+            "message": "Type of parameter \"key\" is unknown",
+            "range": {
+                "start": {
+                    "line": 119,
+                    "character": 17
+                },
+                "end": {
+                    "line": 119,
+                    "character": 20
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"key\"",
+            "range": {
+                "start": {
+                    "line": 119,
+                    "character": 17
+                },
+                "end": {
+                    "line": 119,
+                    "character": 20
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py",
+            "severity": "error",
+            "message": "Type of parameter \"default\" is partially unknown\n  Parameter type is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 119,
+                    "character": 22
+                },
+                "end": {
+                    "line": 119,
+                    "character": 29
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"default\"",
+            "range": {
+                "start": {
+                    "line": 119,
+                    "character": 22
+                },
+                "end": {
+                    "line": 119,
+                    "character": 29
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"key\" in function \"get\"",
+            "range": {
+                "start": {
+                    "line": 122,
+                    "character": 24
+                },
+                "end": {
+                    "line": 122,
+                    "character": 27
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"default\" in function \"get\"\n  Argument type is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 122,
+                    "character": 29
+                },
+                "end": {
+                    "line": 122,
+                    "character": 36
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"value\" in function \"setattr\"\n  Argument type is \"(key: Unknown, default: Unknown | None = None) -> (dict[str, float] | Any)\"",
+            "range": {
+                "start": {
+                    "line": 124,
+                    "character": 47
+                },
+                "end": {
+                    "line": 124,
+                    "character": 55
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_gradio_integration.py",
+            "severity": "error",
+            "message": "Import \"gradio.testing\" could not be resolved",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 9
+                },
+                "end": {
+                    "line": 7,
+                    "character": 23
+                }
+            },
+            "rule": "reportMissingImports"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_gradio_integration.py",
+            "severity": "error",
+            "message": "Type of \"TestClient\" is unknown",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 31
+                },
+                "end": {
+                    "line": 7,
+                    "character": 41
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_gradio_integration.py",
+            "severity": "error",
+            "message": "Type of \"client\" is unknown",
+            "range": {
+                "start": {
+                    "line": 14,
+                    "character": 4
+                },
+                "end": {
+                    "line": 14,
+                    "character": 10
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_gradio_integration.py",
+            "severity": "error",
+            "message": "Object of type \"None\" cannot be called",
+            "range": {
+                "start": {
+                    "line": 14,
+                    "character": 13
+                },
+                "end": {
+                    "line": 14,
+                    "character": 36
+                }
+            },
+            "rule": "reportOptionalCall"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_gradio_integration.py",
+            "severity": "error",
+            "message": "Type of \"result\" is unknown",
+            "range": {
+                "start": {
+                    "line": 15,
+                    "character": 4
+                },
+                "end": {
+                    "line": 15,
+                    "character": 10
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_gradio_integration.py",
+            "severity": "error",
+            "message": "Type of \"chat\" is unknown",
+            "range": {
+                "start": {
+                    "line": 15,
+                    "character": 13
+                },
+                "end": {
+                    "line": 15,
+                    "character": 24
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of \"button_labels\" is partially unknown\n  Type of \"button_labels\" is \"set[Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 22,
+                    "character": 4
+                },
+                "end": {
+                    "line": 22,
+                    "character": 17
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of \"add\" is partially unknown\n  Type of \"add\" is \"(element: Unknown, /) -> None\"",
+            "range": {
+                "start": {
+                    "line": 25,
+                    "character": 12
+                },
+                "end": {
+                    "line": 25,
+                    "character": 29
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[str, list[Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 35,
+                    "character": 12
+                },
+                "end": {
+                    "line": 35,
+                    "character": 27
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"ops\" is unknown",
+            "range": {
+                "start": {
+                    "line": 35,
+                    "character": 34
+                },
+                "end": {
+                    "line": 35,
+                    "character": 37
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"ops\"",
+            "range": {
+                "start": {
+                    "line": 35,
+                    "character": 34
+                },
+                "end": {
+                    "line": 35,
+                    "character": 37
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[str, list[Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 37,
+                    "character": 19
+                },
+                "end": {
+                    "line": 37,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 39,
+                    "character": 12
+                },
+                "end": {
+                    "line": 39,
+                    "character": 27
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"doc_id\" is unknown",
+            "range": {
+                "start": {
+                    "line": 39,
+                    "character": 34
+                },
+                "end": {
+                    "line": 39,
+                    "character": 40
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"doc_id\"",
+            "range": {
+                "start": {
+                    "line": 39,
+                    "character": 34
+                },
+                "end": {
+                    "line": 39,
+                    "character": 40
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"content\" is unknown",
+            "range": {
+                "start": {
+                    "line": 39,
+                    "character": 42
+                },
+                "end": {
+                    "line": 39,
+                    "character": 49
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"content\"",
+            "range": {
+                "start": {
+                    "line": 39,
+                    "character": 42
+                },
+                "end": {
+                    "line": 39,
+                    "character": 49
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"metadata\" is partially unknown\n  Parameter type is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 39,
+                    "character": 51
+                },
+                "end": {
+                    "line": 39,
+                    "character": 59
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"metadata\"",
+            "range": {
+                "start": {
+                    "line": 39,
+                    "character": 51
+                },
+                "end": {
+                    "line": 39,
+                    "character": 59
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 41,
+                    "character": 19
+                },
+                "end": {
+                    "line": 41,
+                    "character": 21
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 43,
+                    "character": 12
+                },
+                "end": {
+                    "line": 43,
+                    "character": 27
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"doc_id\" is unknown",
+            "range": {
+                "start": {
+                    "line": 43,
+                    "character": 34
+                },
+                "end": {
+                    "line": 43,
+                    "character": 40
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"doc_id\"",
+            "range": {
+                "start": {
+                    "line": 43,
+                    "character": 34
+                },
+                "end": {
+                    "line": 43,
+                    "character": 40
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 45,
+                    "character": 19
+                },
+                "end": {
+                    "line": 45,
+                    "character": 21
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 47,
+                    "character": 12
+                },
+                "end": {
+                    "line": 47,
+                    "character": 30
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 49,
+                    "character": 19
+                },
+                "end": {
+                    "line": 49,
+                    "character": 21
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"path\" is unknown",
+            "range": {
+                "start": {
+                    "line": 55,
+                    "character": 33
+                },
+                "end": {
+                    "line": 55,
+                    "character": 37
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"path\"",
+            "range": {
+                "start": {
+                    "line": 55,
+                    "character": 33
+                },
+                "end": {
+                    "line": 55,
+                    "character": 37
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 59,
+                    "character": 12
+                },
+                "end": {
+                    "line": 59,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"files\" is unknown",
+            "range": {
+                "start": {
+                    "line": 59,
+                    "character": 25
+                },
+                "end": {
+                    "line": 59,
+                    "character": 30
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"files\"",
+            "range": {
+                "start": {
+                    "line": 59,
+                    "character": 25
+                },
+                "end": {
+                    "line": 59,
+                    "character": 30
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"progress\" is partially unknown\n  Parameter type is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 59,
+                    "character": 32
+                },
+                "end": {
+                    "line": 59,
+                    "character": 40
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"progress\"",
+            "range": {
+                "start": {
+                    "line": 59,
+                    "character": 32
+                },
+                "end": {
+                    "line": 59,
+                    "character": 40
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"iterable\" in function \"__init__\"",
+            "range": {
+                "start": {
+                    "line": 60,
+                    "character": 35
+                },
+                "end": {
+                    "line": 60,
+                    "character": 40
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 63,
+                    "character": 19
+                },
+                "end": {
+                    "line": 63,
+                    "character": 21
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[str, list[Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 65,
+                    "character": 12
+                },
+                "end": {
+                    "line": 65,
+                    "character": 27
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"ops\" is unknown",
+            "range": {
+                "start": {
+                    "line": 65,
+                    "character": 34
+                },
+                "end": {
+                    "line": 65,
+                    "character": 37
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"ops\"",
+            "range": {
+                "start": {
+                    "line": 65,
+                    "character": 34
+                },
+                "end": {
+                    "line": 65,
+                    "character": 37
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of \"bulk_operations\" is partially unknown\n  Type of \"bulk_operations\" is \"(ops: Unknown) -> dict[str, list[Unknown]]\"",
+            "range": {
+                "start": {
+                    "line": 66,
+                    "character": 19
+                },
+                "end": {
+                    "line": 66,
+                    "character": 56
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[str, list[Unknown]]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 66,
+                    "character": 19
+                },
+                "end": {
+                    "line": 66,
+                    "character": 61
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"ops\" in function \"bulk_operations\"",
+            "range": {
+                "start": {
+                    "line": 66,
+                    "character": 57
+                },
+                "end": {
+                    "line": 66,
+                    "character": 60
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 68,
+                    "character": 12
+                },
+                "end": {
+                    "line": 68,
+                    "character": 27
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"doc_id\" is unknown",
+            "range": {
+                "start": {
+                    "line": 68,
+                    "character": 34
+                },
+                "end": {
+                    "line": 68,
+                    "character": 40
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"doc_id\"",
+            "range": {
+                "start": {
+                    "line": 68,
+                    "character": 34
+                },
+                "end": {
+                    "line": 68,
+                    "character": 40
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"content\" is unknown",
+            "range": {
+                "start": {
+                    "line": 68,
+                    "character": 42
+                },
+                "end": {
+                    "line": 68,
+                    "character": 49
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"content\"",
+            "range": {
+                "start": {
+                    "line": 68,
+                    "character": 42
+                },
+                "end": {
+                    "line": 68,
+                    "character": 49
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"metadata\" is partially unknown\n  Parameter type is \"Unknown | None\"",
+            "range": {
+                "start": {
+                    "line": 68,
+                    "character": 51
+                },
+                "end": {
+                    "line": 68,
+                    "character": 59
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"metadata\"",
+            "range": {
+                "start": {
+                    "line": 68,
+                    "character": 51
+                },
+                "end": {
+                    "line": 68,
+                    "character": 59
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of \"update_document\" is partially unknown\n  Type of \"update_document\" is \"(doc_id: Unknown, content: Unknown, metadata: Unknown | None = None) -> dict[Unknown, Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 69,
+                    "character": 19
+                },
+                "end": {
+                    "line": 69,
+                    "character": 56
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 69,
+                    "character": 19
+                },
+                "end": {
+                    "line": 73,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"doc_id\" in function \"update_document\"",
+            "range": {
+                "start": {
+                    "line": 70,
+                    "character": 16
+                },
+                "end": {
+                    "line": 70,
+                    "character": 22
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"content\" in function \"update_document\"",
+            "range": {
+                "start": {
+                    "line": 71,
+                    "character": 16
+                },
+                "end": {
+                    "line": 71,
+                    "character": 23
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 75,
+                    "character": 12
+                },
+                "end": {
+                    "line": 75,
+                    "character": 27
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"doc_id\" is unknown",
+            "range": {
+                "start": {
+                    "line": 75,
+                    "character": 34
+                },
+                "end": {
+                    "line": 75,
+                    "character": 40
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"doc_id\"",
+            "range": {
+                "start": {
+                    "line": 75,
+                    "character": 34
+                },
+                "end": {
+                    "line": 75,
+                    "character": 40
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of \"delete_document\" is partially unknown\n  Type of \"delete_document\" is \"(doc_id: Unknown) -> dict[Unknown, Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 76,
+                    "character": 19
+                },
+                "end": {
+                    "line": 76,
+                    "character": 56
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 76,
+                    "character": 19
+                },
+                "end": {
+                    "line": 76,
+                    "character": 64
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Argument type is unknown\n  Argument corresponds to parameter \"doc_id\" in function \"delete_document\"",
+            "range": {
+                "start": {
+                    "line": 76,
+                    "character": 57
+                },
+                "end": {
+                    "line": 76,
+                    "character": 63
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 78,
+                    "character": 12
+                },
+                "end": {
+                    "line": 78,
+                    "character": 30
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 79,
+                    "character": 19
+                },
+                "end": {
+                    "line": 79,
+                    "character": 61
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of \"ingest\" is partially unknown\n  Type of \"ingest\" is \"(files: Unknown, progress: Unknown | None = None) -> dict[Unknown, Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 85,
+                    "character": 4
+                },
+                "end": {
+                    "line": 85,
+                    "character": 16
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"p\" is unknown",
+            "range": {
+                "start": {
+                    "line": 85,
+                    "character": 44
+                },
+                "end": {
+                    "line": 85,
+                    "character": 45
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"m\" is unknown",
+            "range": {
+                "start": {
+                    "line": 85,
+                    "character": 47
+                },
+                "end": {
+                    "line": 85,
+                    "character": 48
+                }
+            },
+            "rule": "reportUnknownLambdaType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of \"append\" is partially unknown\n  Type of \"append\" is \"(object: Unknown, /) -> None\"",
+            "range": {
+                "start": {
+                    "line": 85,
+                    "character": 50
+                },
+                "end": {
+                    "line": 85,
+                    "character": 65
+                }
+            },
+            "rule": "reportUnknownMemberType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "\"_queue_files\" is private and used outside of the module in which it is declared",
+            "range": {
+                "start": {
+                    "line": 91,
+                    "character": 39
+                },
+                "end": {
+                    "line": 91,
+                    "character": 51
+                }
+            },
+            "rule": "reportPrivateUsage"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Argument of type \"list[DummyFile]\" cannot be assigned to parameter \"files\" of type \"list[File]\" in function \"_queue_files\"\n  \"DummyFile\" is not assignable to \"File\"",
+            "range": {
+                "start": {
+                    "line": 92,
+                    "character": 9
+                },
+                "end": {
+                    "line": 92,
+                    "character": 34
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "\"_process_all\" is private and used outside of the module in which it is declared",
+            "range": {
+                "start": {
+                    "line": 96,
+                    "character": 18
+                },
+                "end": {
+                    "line": 96,
+                    "character": 30
+                }
+            },
+            "rule": "reportPrivateUsage"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "\"_update_document\" is private and used outside of the module in which it is declared",
+            "range": {
+                "start": {
+                    "line": 99,
+                    "character": 18
+                },
+                "end": {
+                    "line": 99,
+                    "character": 34
+                }
+            },
+            "rule": "reportPrivateUsage"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "\"_delete_document\" is private and used outside of the module in which it is declared",
+            "range": {
+                "start": {
+                    "line": 100,
+                    "character": 18
+                },
+                "end": {
+                    "line": 100,
+                    "character": 34
+                }
+            },
+            "rule": "reportPrivateUsage"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type of parameter \"_path\" is unknown",
+            "range": {
+                "start": {
+                    "line": 108,
+                    "character": 33
+                },
+                "end": {
+                    "line": 108,
+                    "character": 38
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"_path\"",
+            "range": {
+                "start": {
+                    "line": 108,
+                    "character": 33
+                },
+                "end": {
+                    "line": 108,
+                    "character": 38
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "\"_queue_files\" is private and used outside of the module in which it is declared",
+            "range": {
+                "start": {
+                    "line": 115,
+                    "character": 36
+                },
+                "end": {
+                    "line": 115,
+                    "character": 48
+                }
+            },
+            "rule": "reportPrivateUsage"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py",
+            "severity": "error",
+            "message": "Argument of type \"list[DummyFile]\" cannot be assigned to parameter \"files\" of type \"list[File]\" in function \"_queue_files\"\n  \"DummyFile\" is not assignable to \"File\"",
+            "range": {
+                "start": {
+                    "line": 116,
+                    "character": 9
+                },
+                "end": {
+                    "line": 116,
+                    "character": 34
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest_queue.py",
+            "severity": "error",
+            "message": "\"_queue_files\" is private and used outside of the module in which it is declared",
+            "range": {
+                "start": {
+                    "line": 8,
+                    "character": 26
+                },
+                "end": {
+                    "line": 8,
+                    "character": 38
+                }
+            },
+            "rule": "reportPrivateUsage"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest_queue.py",
+            "severity": "error",
+            "message": "\"_process_all\" is private and used outside of the module in which it is declared",
+            "range": {
+                "start": {
+                    "line": 8,
+                    "character": 40
+                },
+                "end": {
+                    "line": 8,
+                    "character": 52
+                }
+            },
+            "rule": "reportPrivateUsage"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest_queue.py",
+            "severity": "error",
+            "message": "\"_document_service\" is private and used outside of the module in which it is declared",
+            "range": {
+                "start": {
+                    "line": 8,
+                    "character": 54
+                },
+                "end": {
+                    "line": 8,
+                    "character": 71
+                }
+            },
+            "rule": "reportPrivateUsage"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest_queue.py",
+            "severity": "error",
+            "message": "Argument of type \"list[DummyFile]\" cannot be assigned to parameter \"files\" of type \"list[File]\" in function \"_queue_files\"\n  \"DummyFile\" is not assignable to \"File\"",
+            "range": {
+                "start": {
+                    "line": 20,
+                    "character": 39
+                },
+                "end": {
+                    "line": 20,
+                    "character": 64
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest_queue.py",
+            "severity": "error",
+            "message": "Type of parameter \"operations\" is unknown",
+            "range": {
+                "start": {
+                    "line": 25,
+                    "character": 22
+                },
+                "end": {
+                    "line": 25,
+                    "character": 32
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest_queue.py",
+            "severity": "error",
+            "message": "Type annotation is missing for parameter \"operations\"",
+            "range": {
+                "start": {
+                    "line": 25,
+                    "character": 22
+                },
+                "end": {
+                    "line": 25,
+                    "character": 32
+                }
+            },
+            "rule": "reportMissingParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ingest_queue.py",
+            "severity": "error",
+            "message": "Argument type is partially unknown\n  Argument corresponds to parameter \"value\" in function \"setattr\"\n  Argument type is \"(operations: Unknown) -> dict[str, list[dict[str, str | dict[str, str]]]]\"",
+            "range": {
+                "start": {
+                    "line": 36,
+                    "character": 62
+                },
+                "end": {
+                    "line": 36,
+                    "character": 75
+                }
+            },
+            "rule": "reportUnknownArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_performance_indicator.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_ranking_controls.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_settings_performance.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_settings_performance.py",
+            "severity": "error",
+            "message": "Import \"gr\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 3,
+                    "character": 17
+                },
+                "end": {
+                    "line": 3,
+                    "character": 19
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_transparency.py",
+            "severity": "error",
+            "message": "Import \"pytest\" is not accessed",
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 7
+                },
+                "end": {
+                    "line": 2,
+                    "character": 13
+                }
+            },
+            "rule": "reportUnusedImport"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_transparency.py",
+            "severity": "error",
+            "message": "Argument of type \"Literal['Doc1']\" cannot be assigned to parameter \"target\" of type \"Block | None\" in function \"__init__\"\n  Type \"Literal['Doc1']\" is not assignable to type \"Block | None\"\n    \"Literal['Doc1']\" is not assignable to \"Block\"\n    \"Literal['Doc1']\" is not assignable to \"None\"",
+            "range": {
+                "start": {
+                    "line": 17,
+                    "character": 37
+                },
+                "end": {
+                    "line": 17,
+                    "character": 43
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_transparency.py",
+            "severity": "error",
+            "message": "Argument of type \"Literal['rank']\" cannot be assigned to parameter \"key\" of type \"SupportsIndex | slice[Any, Any, Any]\" in function \"__getitem__\"\n  Type \"Literal['rank']\" is not assignable to type \"SupportsIndex | slice[Any, Any, Any]\"\n    \"Literal['rank']\" is incompatible with protocol \"SupportsIndex\"\n      \"__index__\" is not present\n    \"Literal['rank']\" is not assignable to \"slice[Any, Any, Any]\"",
+            "range": {
+                "start": {
+                    "line": 48,
+                    "character": 11
+                },
+                "end": {
+                    "line": 48,
+                    "character": 41
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_ui/test_transparency.py",
+            "severity": "error",
+            "message": "Argument of type \"Literal['score']\" cannot be assigned to parameter \"key\" of type \"SupportsIndex | slice[Any, Any, Any]\" in function \"__getitem__\"\n  Type \"Literal['score']\" is not assignable to type \"SupportsIndex | slice[Any, Any, Any]\"\n    \"Literal['score']\" is incompatible with protocol \"SupportsIndex\"\n      \"__index__\" is not present\n    \"Literal['score']\" is not assignable to \"slice[Any, Any, Any]\"",
+            "range": {
+                "start": {
+                    "line": 49,
+                    "character": 11
+                },
+                "end": {
+                    "line": 49,
+                    "character": 42
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py",
+            "severity": "error",
+            "message": "Type of \"backup_config\" is partially unknown\n  Type of \"backup_config\" is \"(path: str, backup_dir: str) -> Tuple[Path, dict[Unknown, Unknown]]\"",
+            "range": {
+                "start": {
+                    "line": 9,
+                    "character": 30
+                },
+                "end": {
+                    "line": 9,
+                    "character": 43
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 15,
+                    "character": 8
+                },
+                "end": {
+                    "line": 15,
+                    "character": 23
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py",
+            "severity": "error",
+            "message": "Type of parameter \"metadata\" is partially unknown\n  Parameter type is \"dict[Unknown, Unknown] | None\"",
+            "range": {
+                "start": {
+                    "line": 16,
+                    "character": 41
+                },
+                "end": {
+                    "line": 16,
+                    "character": 49
+                }
+            },
+            "rule": "reportUnknownParameterType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py",
+            "severity": "error",
+            "message": "Expected type arguments for generic class \"dict\"",
+            "range": {
+                "start": {
+                    "line": 16,
+                    "character": 51
+                },
+                "end": {
+                    "line": 16,
+                    "character": 55
+                }
+            },
+            "rule": "reportMissingTypeArgument"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py",
+            "severity": "error",
+            "message": "Expected type arguments for generic class \"dict\"",
+            "range": {
+                "start": {
+                    "line": 17,
+                    "character": 9
+                },
+                "end": {
+                    "line": 17,
+                    "character": 13
+                }
+            },
+            "rule": "reportMissingTypeArgument"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py",
+            "severity": "error",
+            "message": "Return type, \"dict[Unknown, Unknown]\", is partially unknown",
+            "range": {
+                "start": {
+                    "line": 18,
+                    "character": 15
+                },
+                "end": {
+                    "line": 18,
+                    "character": 34
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py",
+            "severity": "error",
+            "message": "Type of \"_\" is partially unknown\n  Type of \"_\" is \"dict[Unknown, Unknown]\"",
+            "range": {
+                "start": {
+                    "line": 47,
+                    "character": 17
+                },
+                "end": {
+                    "line": 47,
+                    "character": 18
+                }
+            },
+            "rule": "reportUnknownVariableType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py",
+            "severity": "error",
+            "message": "Argument of type \"DummyDense\" cannot be assigned to parameter \"dense\" of type \"DenseRetriever\" in function \"__init__\"\n  \"DummyDense\" is not assignable to \"DenseRetriever\"",
+            "range": {
+                "start": {
+                    "line": 53,
+                    "character": 26
+                },
+                "end": {
+                    "line": 53,
+                    "character": 38
+                }
+            },
+            "rule": "reportArgumentType"
+        },
+        {
+            "file": "/workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py",
+            "severity": "error",
+            "message": "Argument of type \"DummyLexical\" cannot be assigned to parameter \"lexical\" of type \"LexicalBM25\" in function \"__init__\"\n  \"DummyLexical\" is not assignable to \"LexicalBM25\"",
+            "range": {
+                "start": {
+                    "line": 53,
+                    "character": 40
+                },
+                "end": {
+                    "line": 53,
+                    "character": 54
+                }
+            },
+            "rule": "reportArgumentType"
+        }
+    ],
+    "summary": {
+        "filesAnalyzed": 78,
+        "errorCount": 733,
+        "warningCount": 1,
+        "informationCount": 0,
+        "timeInSec": 25.828
+    }
+}
+

--- a/reports/pyright/baseline.output.txt
+++ b/reports/pyright/baseline.output.txt
@@ -1,0 +1,1130 @@
+/workspace/personal-rag-copilot/app.py
+  /workspace/personal-rag-copilot/app.py:4:27 - error: Type of "mount_gradio_app" is partially unknown
+    Type of "mount_gradio_app" is "(app: FastAPI, blocks: Blocks, path: str, server_name: str = "0.0.0.0", server_port: int = 7860, show_api: bool | None = None, app_kwargs: dict[str, Any] | None = None, *, auth: ((...) -> Unknown) | tuple[str, str] | list[tuple[str, str]] | None = None, auth_message: str | None = None, auth_dependency: ((Request) -> (str | None)) | None = None, root_path: str | None = None, allowed_paths: list[str] | None = None, blocked_paths: list[str] | None = None, favicon_path: str | None = None, show_error: bool = True, max_file_size: str | int | None = None, ssr_mode: bool | None = None, node_server_name: str | None = None, node_port: int | None = None, enable_monitoring: bool | None = None, pwa: bool | None = None, i18n: I18n | None = None, mcp_server: bool | None = None) -> FastAPI" (reportUnknownVariableType)
+/workspace/personal-rag-copilot/src/config/__init__.py
+  /workspace/personal-rag-copilot/src/config/__init__.py:5:21 - error: Type of "backup_config" is partially unknown
+    Type of "backup_config" is "(path: str, backup_dir: str) -> Tuple[Path, dict[Unknown, Unknown]]" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/config/__init__.py:5:36 - error: Type of "restore_config" is partially unknown
+    Type of "restore_config" is "(backup_path: str, target_path: str) -> Tuple[Path, dict[Unknown, Unknown]]" (reportUnknownVariableType)
+/workspace/personal-rag-copilot/src/config/backup.py
+  /workspace/personal-rag-copilot/src/config/backup.py:11:5 - error: Return type, "Tuple[Path, dict[Unknown, Unknown]]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/config/backup.py:11:62 - error: Expected type arguments for generic class "dict" (reportMissingTypeArgument)
+  /workspace/personal-rag-copilot/src/config/backup.py:19:12 - error: Return type, "tuple[Path, dict[Unknown, Unknown]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/config/backup.py:22:5 - error: Return type, "Tuple[Path, dict[Unknown, Unknown]]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/config/backup.py:22:71 - error: Expected type arguments for generic class "dict" (reportMissingTypeArgument)
+  /workspace/personal-rag-copilot/src/config/backup.py:28:12 - error: Return type, "tuple[Path, dict[Unknown, Unknown]]", is partially unknown (reportUnknownVariableType)
+/workspace/personal-rag-copilot/src/config/runtime_config.py
+  /workspace/personal-rag-copilot/src/config/runtime_config.py:20:56 - error: Argument type is partially unknown
+    Argument corresponds to parameter "updates" in function "_deep_merge"
+    Argument type is "dict[Unknown, Unknown]" (reportUnknownArgumentType)
+/workspace/personal-rag-copilot/src/config/settings.py
+  /workspace/personal-rag-copilot/src/config/settings.py:70:9 - error: Type of "value" is partially unknown
+    Type of "value" is "Unknown | None" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/config/settings.py:70:17 - error: Type of "get" is partially unknown
+    Type of "get" is "Overload[(key: Unknown, default: None = None, /) -> (Unknown | None), (key: Unknown, default: Unknown, /) -> Unknown, (key: Unknown, default: _T@get, /) -> (Unknown | _T@get)]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/config/settings.py:97:9 - error: Type of "value" is partially unknown
+    Type of "value" is "Unknown | None" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/config/settings.py:97:17 - error: Type of "get" is partially unknown
+    Type of "get" is "Overload[(key: Unknown, default: None = None, /) -> (Unknown | None), (key: Unknown, default: Unknown, /) -> Unknown, (key: Unknown, default: _T@get, /) -> (Unknown | _T@get)]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/config/settings.py:104:5 - error: Type of "auto" is partially unknown
+    Type of "auto" is "Unknown | None" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/config/settings.py:104:12 - error: Type of "get" is partially unknown
+    Type of "get" is "Overload[(key: Unknown, default: None = None, /) -> (Unknown | None), (key: Unknown, default: Unknown, /) -> Unknown, (key: Unknown, default: _T@get, /) -> (Unknown | _T@get)]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/config/settings.py:123:13 - error: Type of "data" is partially unknown
+    Type of "data" is "Any | dict[Unknown, Unknown]" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/config/settings.py:124:16 - error: Return type, "tuple[Any | dict[Unknown, Unknown], dict[str, Any]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/config/settings.py:137:5 - error: Type of "update" is partially unknown
+    Type of "update" is "Overload[(m: SupportsKeysAndGetItem[Unknown, Unknown], /) -> None, (m: SupportsKeysAndGetItem[str, Unknown], /, **kwargs: Unknown) -> None, (m: Iterable[tuple[Unknown, Unknown]], /) -> None, (m: Iterable[tuple[str, Unknown]], /, **kwargs: Unknown) -> None, (**kwargs: Unknown) -> None]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/config/settings.py:138:5 - error: Type of "update" is partially unknown
+    Type of "update" is "Overload[(m: SupportsKeysAndGetItem[Unknown, Unknown], /) -> None, (m: SupportsKeysAndGetItem[str, Unknown], /, **kwargs: Unknown) -> None, (m: Iterable[tuple[Unknown, Unknown]], /) -> None, (m: Iterable[tuple[str, Unknown]], /, **kwargs: Unknown) -> None, (**kwargs: Unknown) -> None]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/config/settings.py:139:5 - error: Type of "update" is partially unknown
+    Type of "update" is "Overload[(m: SupportsKeysAndGetItem[Unknown, Unknown], /) -> None, (m: SupportsKeysAndGetItem[str, Unknown], /, **kwargs: Unknown) -> None, (m: Iterable[tuple[Unknown, Unknown]], /) -> None, (m: Iterable[tuple[str, Unknown]], /, **kwargs: Unknown) -> None, (**kwargs: Unknown) -> None]" (reportUnknownMemberType)
+/workspace/personal-rag-copilot/src/config/validate.py
+  /workspace/personal-rag-copilot/src/config/validate.py:34:9 - error: Type of "current" is partially unknown
+    Type of "current" is "Unknown | None" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/config/validate.py:34:19 - error: Type of "get" is partially unknown
+    Type of "get" is "Overload[(key: Unknown, default: None = None, /) -> (Unknown | None), (key: Unknown, default: Unknown, /) -> Unknown, (key: Unknown, default: _T@get, /) -> (Unknown | _T@get)]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/config/validate.py:35:12 - error: Return type, "Any | Unknown", is partially unknown (reportUnknownVariableType)
+/workspace/personal-rag-copilot/src/evaluation/ragas_integration.py
+  /workspace/personal-rag-copilot/src/evaluation/ragas_integration.py:11:19 - error: Type of "evaluate" is partially unknown
+    Type of "evaluate" is "(dataset: Dataset | EvaluationDataset, metrics: Sequence[Metric] | None = None, llm: BaseRagasLLM | BaseLanguageModel[Unknown] | None = None, embeddings: BaseRagasEmbeddings | BaseRagasEmbedding | Embeddings | None = None, experiment_name: str | None = None, callbacks: list[BaseCallbackHandler] | BaseCallbackManager | None = None, run_config: RunConfig | None = None, token_usage_parser: ((LLMResult | ChatResult) -> TokenUsage) | None = None, raise_exceptions: bool = False, column_map: Dict[str, str] | None = None, show_progress: bool = True, batch_size: int | None = None, _run_id: UUID | None = None, _pbar: tqdm_asyncio[Unknown] | None = None, return_executor: bool = False) -> (EvaluationResult | Executor)" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/evaluation/ragas_integration.py:54:17 - error: Argument of type "dict[str, list[str] | list[List[str]]]" cannot be assigned to parameter "dataset" of type "Dataset | EvaluationDataset"
+    Type "dict[str, list[str] | list[List[str]]]" is not assignable to type "Dataset | EvaluationDataset"
+      "dict[str, list[str] | list[List[str]]]" is not assignable to "Dataset"
+      "dict[str, list[str] | list[List[str]]]" is not assignable to "EvaluationDataset" (reportArgumentType)
+/workspace/personal-rag-copilot/src/integrations/huggingface_models.py
+  /workspace/personal-rag-copilot/src/integrations/huggingface_models.py:55:20 - error: Object of type "None" cannot be called (reportOptionalCall)
+  /workspace/personal-rag-copilot/src/integrations/huggingface_models.py:72:28 - error: Object of type "None" cannot be called (reportOptionalCall)
+  /workspace/personal-rag-copilot/src/integrations/huggingface_models.py:93:28 - error: Object of type "None" cannot be called (reportOptionalCall)
+/workspace/personal-rag-copilot/src/integrations/pinecone_client.py
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:47:9 - error: Return type, "Unknown | None", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:47:29 - error: Type of parameter "func" is partially unknown
+    Parameter type is "(...) -> Unknown" (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:47:35 - error: Expected type arguments for generic class "Callable" (reportMissingTypeArgument)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:47:46 - error: Type of parameter "args" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:47:46 - error: Type annotation is missing for parameter "args" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:47:54 - error: Type of parameter "kwargs" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:47:54 - error: Type annotation is missing for parameter "kwargs" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:53:24 - error: Return type is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:53:30 - error: Argument type is unknown
+    Argument corresponds to parameter "args" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:53:38 - error: Argument type is unknown
+    Argument corresponds to parameter "kwargs" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:72:9 - error: Type of "init" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:72:18 - error: "init" is not a known attribute of module "pinecone" (reportAttributeAccessIssue)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:72:18 - error: "init" is not a known attribute of "None" (reportOptionalMemberAccess)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:83:26 - error: Type of "list_indexes" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:83:35 - error: "list_indexes" is not a known attribute of module "pinecone" (reportAttributeAccessIssue)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:83:35 - error: "list_indexes" is not a known attribute of "None" (reportOptionalMemberAccess)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:85:9 - error: Type of "_with_retries" is partially unknown
+    Type of "_with_retries" is "(func: (...) -> Unknown, ...) -> (Unknown | None)" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:86:13 - error: Type of "create_index" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:86:13 - error: Argument type is unknown
+    Argument corresponds to parameter "func" in function "_with_retries" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:86:22 - error: "create_index" is not a known attribute of module "pinecone" (reportAttributeAccessIssue)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:86:22 - error: "create_index" is not a known attribute of "None" (reportOptionalMemberAccess)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:96:30 - error: Type of "list_indexes" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:96:39 - error: "list_indexes" is not a known attribute of module "pinecone" (reportAttributeAccessIssue)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:96:39 - error: "list_indexes" is not a known attribute of "None" (reportOptionalMemberAccess)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:98:9 - error: Type of "_with_retries" is partially unknown
+    Type of "_with_retries" is "(func: (...) -> Unknown, ...) -> (Unknown | None)" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:98:28 - error: Type of "delete_index" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:98:28 - error: Argument type is unknown
+    Argument corresponds to parameter "func" in function "_with_retries" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:98:37 - error: "delete_index" is not a known attribute of module "pinecone" (reportAttributeAccessIssue)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:98:37 - error: "delete_index" is not a known attribute of "None" (reportOptionalMemberAccess)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:100:9 - error: Return type is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:101:16 - error: Type of "Index" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:101:16 - error: Return type is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:101:25 - error: "Index" is not a known attribute of module "pinecone" (reportAttributeAccessIssue)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:101:25 - error: "Index" is not a known attribute of "None" (reportOptionalMemberAccess)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:105:13 - error: Type of "description" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:105:27 - error: Type of "describe_index" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:105:36 - error: "describe_index" is not a known attribute of module "pinecone" (reportAttributeAccessIssue)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:105:36 - error: "describe_index" is not a known attribute of "None" (reportOptionalMemberAccess)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:106:13 - error: Type of "actual_dim" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:106:26 - error: Type of "dimension" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:111:21 - error: Argument type is unknown
+    Argument corresponds to parameter "args" in function "error" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:131:9 - error: Type of "index" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:138:13 - error: Type of "_with_retries" is partially unknown
+    Type of "_with_retries" is "(func: (...) -> Unknown, ...) -> (Unknown | None)" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:139:17 - error: Type of "upsert" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:139:17 - error: Argument type is unknown
+    Argument corresponds to parameter "func" in function "_with_retries" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:154:9 - error: Type of "index" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:155:16 - error: Type of "_with_retries" is partially unknown
+    Type of "_with_retries" is "(func: (...) -> Unknown, ...) -> (Unknown | None)" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:155:16 - error: Return type, "Unknown | None", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:156:13 - error: Type of "query" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/integrations/pinecone_client.py:156:13 - error: Argument type is unknown
+    Argument corresponds to parameter "func" in function "_with_retries" (reportUnknownArgumentType)
+/workspace/personal-rag-copilot/src/monitoring/auto_tuner.py
+  /workspace/personal-rag-copilot/src/monitoring/auto_tuner.py:37:9 - error: Type of "locks" is partially unknown
+    Type of "locks" is "set[Unknown]" (reportUnknownVariableType)
+/workspace/personal-rag-copilot/src/monitoring/performance.py
+  /workspace/personal-rag-copilot/src/monitoring/performance.py:31:24 - error: Type of parameter "exc_type" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/monitoring/performance.py:31:24 - error: Type annotation is missing for parameter "exc_type" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/monitoring/performance.py:31:34 - error: Type of parameter "exc" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/monitoring/performance.py:31:34 - error: Type annotation is missing for parameter "exc" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/monitoring/performance.py:31:39 - error: Type of parameter "tb" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/monitoring/performance.py:31:39 - error: Type annotation is missing for parameter "tb" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/monitoring/performance.py:75:24 - error: Type of parameter "exc_type" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/monitoring/performance.py:75:24 - error: Type annotation is missing for parameter "exc_type" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/monitoring/performance.py:75:34 - error: Type of parameter "exc" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/monitoring/performance.py:75:34 - error: Type annotation is missing for parameter "exc" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/monitoring/performance.py:75:39 - error: Type of parameter "tb" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/monitoring/performance.py:75:39 - error: Type annotation is missing for parameter "tb" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/monitoring/performance.py:79:13 - error: Type of "__exit__" is partially unknown
+    Type of "__exit__" is "(exc_type: Unknown, exc: Unknown, tb: Unknown) -> None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/monitoring/performance.py:79:32 - error: Argument type is unknown
+    Argument corresponds to parameter "exc_type" in function "__exit__" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/monitoring/performance.py:79:42 - error: Argument type is unknown
+    Argument corresponds to parameter "exc" in function "__exit__" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/monitoring/performance.py:79:47 - error: Argument type is unknown
+    Argument corresponds to parameter "tb" in function "__exit__" (reportUnknownArgumentType)
+/workspace/personal-rag-copilot/src/query_service.py
+  /workspace/personal-rag-copilot/src/query_service.py:47:31 - error: Argument of type "Any | int" cannot be assigned to parameter "enable_rerank" of type "bool" in function "query"
+    Type "Any | int" is not assignable to type "bool"
+      "int" is not assignable to "bool" (reportArgumentType)
+/workspace/personal-rag-copilot/src/ranking/reranker.py
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:36:22 - error: Import "openvino.runtime" could not be resolved (reportMissingImports)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:36:46 - error: Type of "Core" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:38:17 - error: Type of "core" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:43:13 - error: Type of "tokenizer" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:43:30 - error: Type of "from_pretrained" is partially unknown
+    Type of "from_pretrained" is "(pretrained_model_name_or_path: Unknown, ...) -> Unknown" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:49:17 - error: Type of "model" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:49:30 - error: Type of "core" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:49:30 - error: Type of "compile_model" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:56:17 - error: Type of "model" is partially unknown
+    Type of "model" is "Unknown | Any" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:57:21 - error: Type of "from_pretrained" is partially unknown
+    Type of "from_pretrained" is "(pretrained_model_name_or_path: str | PathLike[str], ...) -> (Unknown | Any)" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:62:17 - error: Type of "model" is partially unknown
+    Type of "model" is "Unknown | Any" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:62:17 - error: Type of "to" is partially unknown
+    Type of "to" is "Unknown | Any" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:70:21 - error: Type of "model" is partially unknown
+    Type of "model" is "Unknown | Any" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:70:21 - error: Type of "to" is partially unknown
+    Type of "to" is "Unknown | Any" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:78:13 - error: Type of "inputs" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:78:22 - error: Type of "tokenizer" is partially unknown
+    Type of "tokenizer" is "Unknown | None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:78:22 - error: Object of type "None" cannot be called (reportOptionalCall)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:85:13 - error: Type of "result" is partially unknown
+    Type of "result" is "Any | Unknown" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:85:22 - error: Type of "model" is partially unknown
+    Type of "model" is "Unknown | Any | None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:85:22 - error: Object of type "None" cannot be called (reportOptionalCall)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:86:13 - error: Type of "logits" is partially unknown
+    Type of "logits" is "Any | Unknown" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:86:22 - error: Type of "squeeze" is partially unknown
+    Type of "squeeze" is "Any | Unknown" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:86:27 - error: Argument type is partially unknown
+    Argument corresponds to parameter "i" in function "next"
+    Argument type is "SupportsNext[Any | Unknown]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:86:32 - error: Type of "values" is partially unknown
+    Type of "values" is "Any | Unknown" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:86:32 - error: Argument type is partially unknown
+    Argument corresponds to parameter "object" in function "iter"
+    Argument type is "Any | Unknown" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:87:20 - error: Type of "tolist" is partially unknown
+    Type of "tolist" is "Any | Unknown" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:87:20 - error: Return type, "Any | Unknown", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:88:9 - error: Type of "inputs" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:88:18 - error: Type of "tokenizer" is partially unknown
+    Type of "tokenizer" is "Unknown | None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:88:18 - error: Object of type "None" cannot be called (reportOptionalCall)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:96:13 - error: Type of "inputs" is partially unknown
+    Type of "inputs" is "dict[Unknown, Unknown]" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:96:26 - error: Type of "to" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:96:42 - error: Type of "k" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:96:45 - error: Type of "v" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:96:50 - error: Type of "items" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:98:13 - error: Type of "logits" is partially unknown
+    Type of "logits" is "Any | Unknown" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:98:22 - error: Type of "model" is partially unknown
+    Type of "model" is "Unknown | Any | None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:98:22 - error: Object of type "None" cannot be called (reportOptionalCall)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:98:22 - error: Type of "logits" is partially unknown
+    Type of "logits" is "Any | Unknown" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:98:22 - error: Type of "squeeze" is partially unknown
+    Type of "squeeze" is "Any | Unknown" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:99:16 - error: Type of "cpu" is partially unknown
+    Type of "cpu" is "Any | Unknown" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:99:16 - error: Type of "tolist" is partially unknown
+    Type of "tolist" is "Any | Unknown" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ranking/reranker.py:99:16 - error: Return type, "Any | Unknown", is partially unknown (reportUnknownVariableType)
+/workspace/personal-rag-copilot/src/retrieval/dense.py
+  /workspace/personal-rag-copilot/src/retrieval/dense.py:58:29 - error: Type of "core" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/retrieval/dense.py:59:46 - error: Type of "compile_model" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/retrieval/dense.py:78:21 - error: Type of "encode" is partially unknown
+    Type of "encode" is "Overload[(sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[False] = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[True] = ..., convert_to_tensor: Literal[False] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> ndarray[tuple[Any, ...], dtype[Any]], (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: Literal[True] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[Tensor], (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[dict[str, Tensor]], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> dict[str, Tensor], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/retrieval/dense.py:78:21 - error: Argument type is partially unknown
+    Argument corresponds to parameter "func" in function "to_thread"
+    Argument type is "Overload[(sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[False] = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[True] = ..., convert_to_tensor: Literal[False] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> ndarray[tuple[Any, ...], dtype[Any]], (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: Literal[True] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[Tensor], (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[dict[str, Tensor]], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> dict[str, Tensor], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/retrieval/dense.py:85:17 - error: Type of "encode" is partially unknown
+    Type of "encode" is "Overload[(sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[False] = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[True] = ..., convert_to_tensor: Literal[False] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> ndarray[tuple[Any, ...], dtype[Any]], (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: Literal[True] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[Tensor], (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[dict[str, Tensor]], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> dict[str, Tensor], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/retrieval/dense.py:85:17 - error: Argument type is partially unknown
+    Argument corresponds to parameter "func" in function "to_thread"
+    Argument type is "Overload[(sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[False] = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[True] = ..., convert_to_tensor: Literal[False] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> ndarray[tuple[Any, ...], dtype[Any]], (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: Literal[True] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[Tensor], (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[dict[str, Tensor]], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> dict[str, Tensor], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/retrieval/dense.py:90:16 - error: Type of "tolist" is partially unknown
+    Type of "tolist" is "Unknown | Overload[() -> Any, () -> Any, () -> list[Any], () -> list[list[Any]], () -> list[list[list[Any]]], () -> Any]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/retrieval/dense.py:90:16 - error: Return type, "Any | Unknown", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/retrieval/dense.py:90:27 - error: Cannot access attribute "tolist" for class "object"
+    Attribute "tolist" is unknown (reportAttributeAccessIssue)
+  /workspace/personal-rag-copilot/src/retrieval/dense.py:133:57 - error: Type of "encode" is partially unknown
+    Type of "encode" is "Overload[(sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[False] = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[True] = ..., convert_to_tensor: Literal[False] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> ndarray[tuple[Any, ...], dtype[Any]], (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: Literal[True] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[Tensor], (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[dict[str, Tensor]], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> dict[str, Tensor], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/retrieval/dense.py:133:57 - error: Argument type is partially unknown
+    Argument corresponds to parameter "func" in function "to_thread"
+    Argument type is "Overload[(sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[False] = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[True] = ..., convert_to_tensor: Literal[False] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> ndarray[tuple[Any, ...], dtype[Any]], (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: Literal[True] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[Tensor], (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[dict[str, Tensor]], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> dict[str, Tensor], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/retrieval/dense.py:135:53 - error: Type of "encode" is partially unknown
+    Type of "encode" is "Overload[(sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[False] = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[True] = ..., convert_to_tensor: Literal[False] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> ndarray[tuple[Any, ...], dtype[Any]], (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: Literal[True] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[Tensor], (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[dict[str, Tensor]], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> dict[str, Tensor], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/retrieval/dense.py:135:53 - error: Argument type is partially unknown
+    Argument corresponds to parameter "func" in function "to_thread"
+    Argument type is "Overload[(sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[False] = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: Literal[True] = ..., convert_to_tensor: Literal[False] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> ndarray[tuple[Any, ...], dtype[Any]], (sentences: str | list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: Literal[True] = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor, (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['sentence_embedding', 'token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[Tensor], (sentences: list[str] | ndarray[tuple[Any, ...], dtype[Any]], prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> list[dict[str, Tensor]], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: None = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> dict[str, Tensor], (sentences: str, prompt_name: str | None = ..., prompt: str | None = ..., batch_size: int = ..., show_progress_bar: bool | None = ..., output_value: Literal['token_embeddings'] = ..., precision: Literal['float32', 'int8', 'uint8', 'binary', 'ubinary'] = ..., convert_to_numpy: bool = ..., convert_to_tensor: bool = ..., device: str | list[str | device] | None = ..., normalize_embeddings: bool = ..., truncate_dim: int | None = ..., pool: dict[Literal['input', 'output', 'processes'], Any] | None = ..., chunk_size: int | None = ..., **kwargs: Unknown) -> Tensor]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/retrieval/dense.py:136:20 - error: Type of "tolist" is partially unknown
+    Type of "tolist" is "Unknown | (() -> list[Unknown])" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/retrieval/dense.py:136:20 - error: Return type, "tuple[list[Unknown] | Unknown, dict[str, Any]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/retrieval/dense.py:136:30 - error: Cannot access attribute "tolist" for class "object"
+    Attribute "tolist" is unknown (reportAttributeAccessIssue)
+/workspace/personal-rag-copilot/src/retrieval/hybrid.py
+  /workspace/personal-rag-copilot/src/retrieval/hybrid.py:44:13 - error: Type of "results" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/retrieval/hybrid.py:44:22 - error: Type of "meta" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/retrieval/hybrid.py:44:29 - error: "CoroutineType[Any, Any, Tuple[List[Tuple[str, float]], Dict[str, Any]]]" is not iterable
+    "__iter__" method not defined (reportGeneralTypeIssues)
+  /workspace/personal-rag-copilot/src/retrieval/hybrid.py:45:13 - error: Type of "wrapped" is partially unknown
+    Type of "wrapped" is "list[dict[str, Unknown | str]]" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/retrieval/hybrid.py:47:21 - error: Type of "doc_id" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/retrieval/hybrid.py:47:29 - error: Type of "score" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/retrieval/hybrid.py:49:13 - error: Type of "update" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/retrieval/hybrid.py:50:20 - error: Return type, "tuple[list[dict[str, Unknown | str]], Unknown]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/retrieval/hybrid.py:68:13 - error: Type of "dense_results" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/retrieval/hybrid.py:68:28 - error: Type of "_" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/retrieval/hybrid.py:68:32 - error: "CoroutineType[Any, Any, Tuple[List[Tuple[str, float]], Dict[str, Any]]]" is not iterable
+    "__iter__" method not defined (reportGeneralTypeIssues)
+/workspace/personal-rag-copilot/src/retrieval/lexical.py
+  /workspace/personal-rag-copilot/src/retrieval/lexical.py:5:6 - error: Stub file not found for "rank_bm25" (reportMissingTypeStubs)
+  /workspace/personal-rag-copilot/src/retrieval/lexical.py:8:10 - error: Stub file not found for "nltk.stem" (reportMissingTypeStubs)
+  /workspace/personal-rag-copilot/src/retrieval/lexical.py:32:24 - error: Object of type "None" cannot be called (reportOptionalCall)
+  /workspace/personal-rag-copilot/src/retrieval/lexical.py:46:13 - error: Type of "tokens" is partially unknown
+    Type of "tokens" is "list[Unknown | str]" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/retrieval/lexical.py:46:23 - error: Type of "stem" is partially unknown
+    Type of "stem" is "(word: Unknown, to_lowercase: bool = True) -> Unknown" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/retrieval/lexical.py:47:16 - error: Return type, "list[Unknown | str] | List[str]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/retrieval/lexical.py:62:17 - error: Type of "append" is partially unknown
+    Type of "append" is "(object: Unknown, /) -> None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/retrieval/lexical.py:65:20 - error: Return type, "tuple[list[Unknown], dict[str, Any]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/retrieval/lexical.py:65:60 - error: Argument type is partially unknown
+    Argument corresponds to parameter "obj" in function "len"
+    Argument type is "list[Unknown]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/retrieval/lexical.py:78:13 - error: Type of "scores" is partially unknown
+    Type of "scores" is "ndarray[tuple[int], dtype[float64]] | Unknown" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/retrieval/lexical.py:78:22 - error: Type of "get_scores" is partially unknown
+    Type of "get_scores" is "(query: Unknown) -> (ndarray[tuple[int], dtype[float64]] | Unknown)" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/retrieval/lexical.py:80:35 - error: Argument type is partially unknown
+    Argument corresponds to parameter "iter2" in function "__new__"
+    Argument type is "ndarray[tuple[int], dtype[float64]] | Unknown" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/retrieval/lexical.py:82:20 - error: Type "tuple[list[tuple[str, float64]], dict[str, Any]]" is not assignable to return type "Tuple[List[Tuple[str, float]], Dict[str, Any]]"
+    "list[tuple[str, float64]]" is not assignable to "List[Tuple[str, float]]"
+      Type parameter "_T@list" is invariant, but "tuple[str, float64]" is not the same as "Tuple[str, float]"
+      Consider switching from "list" to "Sequence" which is covariant (reportReturnType)
+/workspace/personal-rag-copilot/src/services/document_service.py
+  /workspace/personal-rag-copilot/src/services/document_service.py:52:32 - error: Argument of type "Path" cannot be assigned to parameter "docx" of type "str | IO[bytes] | None" in function "Document"
+    Type "Path" is not assignable to type "str | IO[bytes] | None"
+      "Path" is not assignable to "str"
+      "Path" is not assignable to "IO[bytes]"
+      "Path" is not assignable to "None" (reportArgumentType)
+  /workspace/personal-rag-copilot/src/services/document_service.py:133:13 - error: Type of "dense_ids" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/services/document_service.py:133:24 - error: Type of "dense_meta" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/services/document_service.py:133:37 - error: "CoroutineType[Any, Any, Tuple[List[str], Dict[str, Any]]]" is not iterable
+    "__iter__" method not defined (reportGeneralTypeIssues)
+/workspace/personal-rag-copilot/src/ui/chat.py
+  /workspace/personal-rag-copilot/src/ui/chat.py:24:9 - error: Return type, "tuple[list[Unknown], dict[str, str | dict[Unknown, Unknown]]]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/chat.py:25:16 - error: Return type, "tuple[list[Unknown], dict[str, str | dict[Unknown, Unknown]]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ui/chat.py:32:30 - error: Argument of type "_StubHybridRetriever" cannot be assigned to parameter "retriever" of type "HybridRetriever" in function "__init__"
+    "_StubHybridRetriever" is not assignable to "HybridRetriever" (reportArgumentType)
+  /workspace/personal-rag-copilot/src/ui/chat.py:74:9 - error: Type of "append" is partially unknown
+    Type of "append" is "(object: Unknown, /) -> None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/chat.py:82:5 - error: Type of "metadata" is partially unknown
+    Type of "metadata" is "dict[str, Any | dict[str, Any | None] | list[Unknown]]" (reportUnknownVariableType)
+/workspace/personal-rag-copilot/src/ui/components/__init__.py
+  /workspace/personal-rag-copilot/src/ui/components/__init__.py:3:12 - error: "ranking_controls" is specified in __all__ but is not present in module (reportUnsupportedDunderAll)
+  /workspace/personal-rag-copilot/src/ui/components/__init__.py:3:32 - error: "transparency" is specified in __all__ but is not present in module (reportUnsupportedDunderAll)
+/workspace/personal-rag-copilot/src/ui/components/transparency.py
+  /workspace/personal-rag-copilot/src/ui/components/transparency.py:29:13 - error: Type of "append" is partially unknown
+    Type of "append" is "(object: Unknown, /) -> None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/components/transparency.py:31:13 - error: Type of "append" is partially unknown
+    Type of "append" is "(object: Unknown, /) -> None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/components/transparency.py:33:13 - error: Type of "append" is partially unknown
+    Type of "append" is "(object: Unknown, /) -> None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/components/transparency.py:35:13 - error: Type of "append" is partially unknown
+    Type of "append" is "(object: Unknown, /) -> None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/components/transparency.py:36:34 - error: Argument type is partially unknown
+    Argument corresponds to parameter "iterable" in function "join"
+    Argument type is "list[Unknown]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/components/transparency.py:58:5 - error: Type of "content" is partially unknown
+    Type of "content" is "dict[Unknown, Unknown]" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ui/components/transparency.py:158:13 - error: Type of "append" is partially unknown
+    Type of "append" is "(object: Unknown, /) -> None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/components/transparency.py:160:32 - error: Argument type is partially unknown
+    Argument corresponds to parameter "iterable" in function "join"
+    Argument type is "list[Unknown]" (reportUnknownArgumentType)
+/workspace/personal-rag-copilot/src/ui/evaluate.py
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:9:8 - error: Stub file not found for "pandas" (reportMissingTypeStubs)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:10:8 - error: Stub file not found for "plotly.express" (reportMissingTypeStubs)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:31:37 - error: Argument of type "list[str]" cannot be assigned to parameter "columns" of type "Axes | None" in function "__init__"
+    Type "list[str]" is not assignable to type "Axes | None"
+      "list[str]" is not assignable to "ExtensionArray"
+      "list[str]" is not assignable to "ndarray[_AnyShape, dtype[Any]]"
+      "list[str]" is not assignable to "Index"
+      "list[str]" is not assignable to "Series"
+      "list[str]" is incompatible with protocol "SequenceNotStr[Unknown]"
+        "index" is an incompatible type
+          Type "(value: str, start: SupportsIndex = 0, stop: SupportsIndex = sys.maxsize, /) -> int" is not assignable to type "(value: Any, /, start: int = 0, stop: int = ...) -> int"
+    ... (reportArgumentType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:48:13 - error: No overloads for "sum" match the provided arguments (reportCallIssue)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:48:17 - error: Argument of type "Generator[str | Any, None, None]" cannot be assigned to parameter "iterable" of type "Iterable[_SupportsSumNoDefaultT@sum]" in function "sum"
+    "Generator[str | Any, None, None]" is not assignable to "Iterable[_SupportsSumNoDefaultT@sum]"
+      Type parameter "_T_co@Iterable" is covariant, but "str | Any" is not a subtype of "_SupportsSumNoDefaultT@sum"
+        Type "str | Any" is not assignable to type "_SupportsSumWithNoDefaultGiven"
+          Type "str | Any" is not assignable to type "_SupportsSumWithNoDefaultGiven"
+            "str" is incompatible with protocol "_SupportsSumWithNoDefaultGiven" (reportArgumentType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:52:9 - error: Type of "append" is partially unknown
+    Type of "append" is "(object: Unknown, /) -> None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:53:42 - error: Argument of type "list[str]" cannot be assigned to parameter "columns" of type "Axes | None" in function "__init__"
+    Type "list[str]" is not assignable to type "Axes | None"
+      "list[str]" is not assignable to "ExtensionArray"
+      "list[str]" is not assignable to "ndarray[_AnyShape, dtype[Any]]"
+      "list[str]" is not assignable to "Index"
+      "list[str]" is not assignable to "Series"
+      "list[str]" is incompatible with protocol "SequenceNotStr[Unknown]"
+        "index" is an incompatible type
+          Type "(value: str, start: SupportsIndex = 0, stop: SupportsIndex = sys.maxsize, /) -> int" is not assignable to type "(value: Any, /, start: int = 0, stop: int = ...) -> int"
+    ... (reportArgumentType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:81:15 - error: Type of "line" is partially unknown
+    Type of "line" is "(data_frame: Unknown | None = None, x: Unknown | None = None, y: Unknown | None = None, line_group: Unknown | None = None, color: Unknown | None = None, line_dash: Unknown | None = None, symbol: Unknown | None = None, hover_name: Unknown | None = None, hover_data: Unknown | None = None, custom_data: Unknown | None = None, text: Unknown | None = None, facet_row: Unknown | None = None, facet_col: Unknown | None = None, facet_col_wrap: int = 0, facet_row_spacing: Unknown | None = None, facet_col_spacing: Unknown | None = None, error_x: Unknown | None = None, error_x_minus: Unknown | None = None, error_y: Unknown | None = None, error_y_minus: Unknown | None = None, animation_frame: Unknown | None = None, animation_group: Unknown | None = None, category_orders: Unknown | None = None, labels: Unknown | None = None, orientation: Unknown | None = None, color_discrete_sequence: Unknown | None = None, color_discrete_map: Unknown | None = None, line_dash_sequence: Unknown | None = None, line_dash_map: Unknown | None = None, symbol_sequence: Unknown | None = None, symbol_map: Unknown | None = None, markers: bool = False, log_x: bool = False, log_y: bool = False, range_x: Unknown | None = None, range_y: Unknown | None = None, line_shape: Unknown | None = None, render_mode: str = "auto", title: Unknown | None = None, subtitle: Unknown | None = None, template: Unknown | None = None, width: Unknown | None = None, height: Unknown | None = None) -> Figure" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:97:23 - error: Type of "to_datetime" is partially unknown
+    Type of "to_datetime" is "Overload[(arg: float | str | date | datetime64[date | int | None], errors: Literal['ignore', 'raise', 'coerce'] = ..., dayfirst: bool = ..., yearfirst: bool = ..., utc: bool = ..., format: str | None = ..., exact: bool = ..., unit: str | None = ..., infer_datetime_format: bool = ..., origin: ... = ..., cache: bool = ...) -> Timestamp, (arg: Series | FulldatetimeDict | DataFrame, errors: Literal['ignore', 'raise', 'coerce'] = ..., dayfirst: bool = ..., yearfirst: bool = ..., utc: bool = ..., format: str | None = ..., exact: bool = ..., unit: str | None = ..., infer_datetime_format: bool = ..., origin: ... = ..., cache: bool = ...) -> Series, (arg: list[Unknown] | tuple[Unknown, ...] | Index | ExtensionArray | ndarray[tuple[Any, ...], dtype[Any]], errors: Literal['ignore', 'raise', 'coerce'] = ..., dayfirst: bool = ..., yearfirst: bool = ..., utc: bool = ..., format: str | None = ..., exact: bool = ..., unit: str | None = ..., infer_datetime_format: bool = ..., origin: ... = ..., cache: bool = ...) -> DatetimeIndex]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:97:38 - error: Argument type is partially unknown
+    Argument corresponds to parameter "arg" in function "to_datetime"
+    Argument type is "Series | Unknown | DataFrame" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:98:5 - error: Type of "avg_score" is partially unknown
+    Type of "avg_score" is "Series | float | int | Unknown" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:98:17 - error: Type of "mean" is partially unknown
+    Type of "mean" is "((axis: int | Literal['index', 'columns', 'rows'] | None = 0, skipna: bool = True, numeric_only: bool = False, **kwargs: Unknown) -> (Series | float)) | Unknown | ((axis: int | Literal['index', 'columns', 'rows'] | None = 0, skipna: bool = True, numeric_only: bool = False, **kwargs: Unknown) -> (Series | float | int))" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:100:11 - error: Type of "line" is partially unknown
+    Type of "line" is "(data_frame: Unknown | None = None, x: Unknown | None = None, y: Unknown | None = None, line_group: Unknown | None = None, color: Unknown | None = None, line_dash: Unknown | None = None, symbol: Unknown | None = None, hover_name: Unknown | None = None, hover_data: Unknown | None = None, custom_data: Unknown | None = None, text: Unknown | None = None, facet_row: Unknown | None = None, facet_col: Unknown | None = None, facet_col_wrap: int = 0, facet_row_spacing: Unknown | None = None, facet_col_spacing: Unknown | None = None, error_x: Unknown | None = None, error_x_minus: Unknown | None = None, error_y: Unknown | None = None, error_y_minus: Unknown | None = None, animation_frame: Unknown | None = None, animation_group: Unknown | None = None, category_orders: Unknown | None = None, labels: Unknown | None = None, orientation: Unknown | None = None, color_discrete_sequence: Unknown | None = None, color_discrete_map: Unknown | None = None, line_dash_sequence: Unknown | None = None, line_dash_map: Unknown | None = None, symbol_sequence: Unknown | None = None, symbol_map: Unknown | None = None, markers: bool = False, log_x: bool = False, log_y: bool = False, range_x: Unknown | None = None, range_y: Unknown | None = None, line_shape: Unknown | None = None, render_mode: str = "auto", title: Unknown | None = None, subtitle: Unknown | None = None, template: Unknown | None = None, width: Unknown | None = None, height: Unknown | None = None) -> Figure" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:106:5 - error: Type of "correlations" is partially unknown
+    Type of "correlations" is "str | Unknown" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:107:9 - error: Type of "corr" is partially unknown
+    Type of "corr" is "((other: Series, method: ((ndarray[tuple[Any, ...], dtype[Any]], ndarray[tuple[Any, ...], dtype[Any]]) -> float) | Literal['pearson', 'kendall', 'spearman'] = "pearson", min_periods: int | None = None) -> float) | Unknown | ((method: ((ndarray[tuple[Any, ...], dtype[Any]], ndarray[tuple[Any, ...], dtype[Any]]) -> float) | Literal['pearson', 'kendall', 'spearman'] = "pearson", min_periods: int = 1, numeric_only: bool = False) -> DataFrame)" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:107:9 - error: Argument missing for parameter "other" (reportCallIssue)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:107:9 - error: Type of "to_string" is partially unknown
+    Type of "to_string" is "Overload[(buf: None = ..., columns: ExtensionArray | ndarray[tuple[Any, ...], dtype[Any]] | Index | Series | SequenceNotStr[Unknown] | range | None = ..., col_space: int | list[int] | dict[Hashable, int] | None = ..., header: bool | SequenceNotStr[str] = ..., index: bool = ..., na_rep: str = ..., formatters: list[(...) -> Unknown] | tuple[(...) -> Unknown, ...] | Mapping[str | int, (...) -> Unknown] | None = ..., float_format: str | ((...) -> Unknown) | EngFormatter | None = ..., sparsify: bool | None = ..., index_names: bool = ..., justify: str | None = ..., max_rows: int | None = ..., max_cols: int | None = ..., show_dimensions: bool = ..., decimal: str = ..., line_width: int | None = ..., min_rows: int | None = ..., max_colwidth: int | None = ..., encoding: str | None = ...) -> str, (buf: str | PathLike[str] | WriteBuffer[str], columns: ExtensionArray | ndarray[tuple[Any, ...], dtype[Any]] | Index | Series | SequenceNotStr[Unknown] | range | None = ..., col_space: int | list[int] | dict[Hashable, int] | None = ..., header: bool | SequenceNotStr[str] = ..., index: bool = ..., na_rep: str = ..., formatters: list[(...) -> Unknown] | tuple[(...) -> Unknown, ...] | Mapping[str | int, (...) -> Unknown] | None = ..., float_format: str | ((...) -> Unknown) | EngFormatter | None = ..., sparsify: bool | None = ..., index_names: bool = ..., justify: str | None = ..., max_rows: int | None = ..., max_cols: int | None = ..., show_dimensions: bool = ..., decimal: str = ..., line_width: int | None = ..., min_rows: int | None = ..., max_colwidth: int | None = ..., encoding: str | None = ...) -> None] | Unknown" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:116:5 - error: Type of "alerts_df" is partially unknown
+    Type of "alerts_df" is "Series | Any | ndarray[tuple[Any, ...], dtype[Any]] | Unknown | DataFrame" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:121:8 - error: Type of "empty" is partially unknown
+    Type of "empty" is "bool | Any | Unknown" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:121:18 - error: Cannot access attribute "empty" for class "ndarray[_AnyShape, dtype[Any]]"
+    Attribute "empty" is unknown (reportAttributeAccessIssue)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:124:9 - error: Type of "alerts" is partially unknown
+    Type of "alerts" is "str | Any | Unknown" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:124:18 - error: Type of "to_string" is partially unknown
+    Type of "to_string" is "Overload[(buf: None = ..., na_rep: str = ..., float_format: str | None = ..., header: bool = ..., index: bool = ..., length: bool = ..., dtype: ... = ..., name: ... = ..., max_rows: int | None = ..., min_rows: int | None = ...) -> str, (buf: str | PathLike[str] | WriteBuffer[str], na_rep: str = ..., float_format: str | None = ..., header: bool = ..., index: bool = ..., length: bool = ..., dtype: ... = ..., name: ... = ..., max_rows: int | None = ..., min_rows: int | None = ...) -> None] | Any | Unknown | Overload[(buf: None = ..., columns: ExtensionArray | ndarray[tuple[Any, ...], dtype[Any]] | Index | Series | SequenceNotStr[Unknown] | range | None = ..., col_space: int | list[int] | dict[Hashable, int] | None = ..., header: bool | SequenceNotStr[str] = ..., index: bool = ..., na_rep: str = ..., formatters: list[(...) -> Unknown] | tuple[(...) -> Unknown, ...] | Mapping[str | int, (...) -> Unknown] | None = ..., float_format: str | ((...) -> Unknown) | EngFormatter | None = ..., sparsify: bool | None = ..., index_names: bool = ..., justify: str | None = ..., max_rows: int | None = ..., max_cols: int | None = ..., show_dimensions: bool = ..., decimal: str = ..., line_width: int | None = ..., min_rows: int | None = ..., max_colwidth: int | None = ..., encoding: str | None = ...) -> str, (buf: str | PathLike[str] | WriteBuffer[str], columns: ExtensionArray | ndarray[tuple[Any, ...], dtype[Any]] | Index | Series | SequenceNotStr[Unknown] | range | None = ..., col_space: int | list[int] | dict[Hashable, int] | None = ..., header: bool | SequenceNotStr[str] = ..., index: bool = ..., na_rep: str = ..., formatters: list[(...) -> Unknown] | tuple[(...) -> Unknown, ...] | Mapping[str | int, (...) -> Unknown] | None = ..., float_format: str | ((...) -> Unknown) | EngFormatter | None = ..., sparsify: bool | None = ..., index_names: bool = ..., justify: str | None = ..., max_rows: int | None = ..., max_cols: int | None = ..., show_dimensions: bool = ..., decimal: str = ..., line_width: int | None = ..., min_rows: int | None = ..., max_colwidth: int | None = ..., encoding: str | None = ...) -> None]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:124:28 - error: Cannot access attribute "to_string" for class "ndarray[_AnyShape, dtype[Any]]"
+    Attribute "to_string" is unknown (reportAttributeAccessIssue)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:125:5 - error: Type of "avg_relevancy" is partially unknown
+    Type of "avg_relevancy" is "Series | float | int | Unknown" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:125:21 - error: Type of "mean" is partially unknown
+    Type of "mean" is "((axis: int | Literal['index', 'columns', 'rows'] | None = 0, skipna: bool = True, numeric_only: bool = False, **kwargs: Unknown) -> (Series | float)) | Unknown | ((axis: int | Literal['index', 'columns', 'rows'] | None = 0, skipna: bool = True, numeric_only: bool = False, **kwargs: Unknown) -> (Series | float | int))" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:126:5 - error: Type of "avg_precision" is partially unknown
+    Type of "avg_precision" is "Series | float | int | Unknown" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:126:21 - error: Type of "mean" is partially unknown
+    Type of "mean" is "((axis: int | Literal['index', 'columns', 'rows'] | None = 0, skipna: bool = True, numeric_only: bool = False, **kwargs: Unknown) -> (Series | float)) | Unknown | ((axis: int | Literal['index', 'columns', 'rows'] | None = 0, skipna: bool = True, numeric_only: bool = False, **kwargs: Unknown) -> (Series | float | int))" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:127:5 - error: Type of "avg_faithfulness" is partially unknown
+    Type of "avg_faithfulness" is "Series | float | int | Unknown" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:127:24 - error: Type of "mean" is partially unknown
+    Type of "mean" is "((axis: int | Literal['index', 'columns', 'rows'] | None = 0, skipna: bool = True, numeric_only: bool = False, **kwargs: Unknown) -> (Series | float)) | Unknown | ((axis: int | Literal['index', 'columns', 'rows'] | None = 0, skipna: bool = True, numeric_only: bool = False, **kwargs: Unknown) -> (Series | float | int))" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:129:9 - error: Argument of type "dict[str, Series | float | int | Unknown]" cannot be assigned to parameter "metrics" of type "Dict[str, float]" in function "generate_recommendations"
+    Type "Series | float | int | Unknown" is not assignable to type "float"
+      "Series" is not assignable to "float"
+    Type "Series | float | int | Unknown" is not assignable to type "float"
+      "Series" is not assignable to "float"
+    Type "Series | float | int | Unknown" is not assignable to type "float"
+      "Series" is not assignable to "float" (reportArgumentType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:140:17 - error: Type of "to_csv" is partially unknown
+    Type of "to_csv" is "Overload[(path_or_buf: None = ..., sep: str = ..., na_rep: str = ..., float_format: str | ((...) -> Unknown) | None = ..., columns: Sequence[Hashable] | None = ..., header: bool | list[str] = ..., index: bool = ..., index_label: Hashable | Sequence[Hashable] | None = ..., mode: str = ..., encoding: str | None = ..., compression: dict[str, Any] | Literal['infer', 'gzip', 'bz2', 'zip', 'xz', 'zstd', 'tar'] | None = ..., quoting: int | None = ..., quotechar: str = ..., lineterminator: str | None = ..., chunksize: int | None = ..., date_format: str | None = ..., doublequote: bool = ..., escapechar: str | None = ..., decimal: str = ..., errors: Literal['strict', 'ignore', 'replace', 'surrogateescape', 'xmlcharrefreplace', 'backslashreplace', 'namereplace'] = ..., storage_options: dict[str, Any] | None = ...) -> str, (path_or_buf: str | PathLike[str] | WriteBuffer[bytes] | WriteBuffer[str], sep: str = ..., na_rep: str = ..., float_format: str | ((...) -> Unknown) | None = ..., columns: Sequence[Hashable] | None = ..., header: bool | list[str] = ..., index: bool = ..., index_label: Hashable | Sequence[Hashable] | None = ..., mode: str = ..., encoding: str | None = ..., compression: dict[str, Any] | Literal['infer', 'gzip', 'bz2', 'zip', 'xz', 'zstd', 'tar'] | None = ..., quoting: int | None = ..., quotechar: str = ..., lineterminator: str | None = ..., chunksize: int | None = ..., date_format: str | None = ..., doublequote: bool = ..., escapechar: str | None = ..., decimal: str = ..., errors: Literal['strict', 'ignore', 'replace', 'surrogateescape', 'xmlcharrefreplace', 'backslashreplace', 'namereplace'] = ..., storage_options: dict[str, Any] | None = ...) -> None]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:141:18 - error: Type of "to_json" is partially unknown
+    Type of "to_json" is "(path_or_buf: str | PathLike[str] | WriteBuffer[bytes] | WriteBuffer[str] | None = None, orient: Literal['split', 'records', 'index', 'table', 'columns', 'values'] | None = None, date_format: str | None = None, double_precision: int = 10, force_ascii: bool = True, date_unit: Literal['s', 'ms', 'us', 'ns'] = "ms", default_handler: ((Any) -> (str | float | bool | list[Unknown] | dict[Unknown, Unknown] | None)) | None = None, lines: bool = False, compression: dict[str, Any] | Literal['infer', 'gzip', 'bz2', 'zip', 'xz', 'zstd', 'tar'] | None = "infer", index: bool | None = None, indent: int | None = None, storage_options: dict[str, Any] | None = None, mode: Literal['a', 'w'] = "w") -> (str | None)" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:141:47 - error: "encode" is not a known attribute of "None" (reportOptionalMemberAccess)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:144:12 - error: Return type, "tuple[str, Figure, Series | Unknown | DataFrame, str | Unknown, str | Any | Unknown, str, dict[str, Any], dict[str, Any]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ui/evaluate.py:147:9 - error: Type "tuple[str, Figure, Series | Unknown | DataFrame, str | Unknown, str | Any | Unknown, str, dict[str, Any], dict[str, Any]]" is not assignable to return type "Tuple[str, Any, DataFrame, str, str, str, Dict[str, Any], Dict[str, Any]]"
+    Type "Series | Unknown | DataFrame" is not assignable to type "DataFrame"
+      "Series" is not assignable to "DataFrame" (reportReturnType)
+/workspace/personal-rag-copilot/src/ui/ingest.py
+  /workspace/personal-rag-copilot/src/ui/ingest.py:25:9 - error: Return type, "tuple[list[Unknown], dict[Unknown, Unknown]]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:25:29 - error: Type of parameter "args" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:25:29 - error: Type annotation is missing for parameter "args" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:25:37 - error: Type of parameter "kwargs" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:25:37 - error: Type annotation is missing for parameter "kwargs" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:26:16 - error: Return type, "tuple[list[Unknown], dict[Unknown, Unknown]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:28:9 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:28:32 - error: Type of parameter "args" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:28:32 - error: Type annotation is missing for parameter "args" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:28:40 - error: Type of parameter "kwargs" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:28:40 - error: Type annotation is missing for parameter "kwargs" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:29:16 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:31:9 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:31:32 - error: Type of parameter "args" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:31:32 - error: Type annotation is missing for parameter "args" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:31:40 - error: Type of parameter "kwargs" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:31:40 - error: Type annotation is missing for parameter "kwargs" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:32:16 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:34:9 - error: Return type, "tuple[Literal[True], dict[Unknown, Unknown]]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:34:31 - error: Type of parameter "args" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:34:31 - error: Type annotation is missing for parameter "args" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:34:39 - error: Type of parameter "kwargs" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:34:39 - error: Type annotation is missing for parameter "kwargs" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:35:16 - error: Return type, "tuple[Literal[True], dict[Unknown, Unknown]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:41:9 - error: Return type, "tuple[list[Unknown], dict[Unknown, Unknown]]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:41:32 - error: Type of parameter "args" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:41:32 - error: Type annotation is missing for parameter "args" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:41:40 - error: Type of parameter "kwargs" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:41:40 - error: Type annotation is missing for parameter "kwargs" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:42:16 - error: Return type, "tuple[list[Unknown], dict[Unknown, Unknown]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:46:5 - error: Argument of type "_DummyDenseRetriever" cannot be assigned to parameter "dense_retriever" of type "DenseRetriever" in function "__init__"
+    "_DummyDenseRetriever" is not assignable to "DenseRetriever" (reportArgumentType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:47:5 - error: Argument of type "_DummyLexicalRetriever" cannot be assigned to parameter "lexical_retriever" of type "LexicalBM25" in function "__init__"
+    "_DummyLexicalRetriever" is not assignable to "LexicalBM25" (reportArgumentType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:79:33 - error: Type of "name" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:79:33 - error: Argument type is unknown
+    Argument corresponds to parameter "name" in function "_sanitize_name" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:79:38 - error: Cannot access attribute "name" for class "File"
+    Attribute "name" is unknown (reportAttributeAccessIssue)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:81:40 - error: Type of "name" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:81:40 - error: Argument type is unknown
+    Argument corresponds to parameter "path_str" in function "_sanitize_path" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:81:45 - error: Cannot access attribute "name" for class "File"
+    Attribute "name" is unknown (reportAttributeAccessIssue)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:140:9 - error: Type of "metadata" is partially unknown
+    Type of "metadata" is "Any | dict[Unknown, Unknown]" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/ui/ingest.py:143:63 - error: Argument type is partially unknown
+    Argument corresponds to parameter "metadata" in function "update_document"
+    Argument type is "Any | dict[Unknown, Unknown]" (reportUnknownArgumentType)
+/workspace/personal-rag-copilot/src/ui/settings.py
+  /workspace/personal-rag-copilot/src/ui/settings.py:8:8 - error: Stub file not found for "pandas" (reportMissingTypeStubs)
+  /workspace/personal-rag-copilot/src/ui/settings.py:46:46 - error: "_latencies" is protected and used outside of the class in which it is declared (reportPrivateUsage)
+  /workspace/personal-rag-copilot/src/ui/settings.py:63:29 - error: Type of parameter "file" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:63:29 - error: Type annotation is missing for parameter "file" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:71:45 - error: Type of "name" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:71:45 - error: Argument type is unknown
+    Argument corresponds to parameter "path" in function "load_settings" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:72:20 - error: Variable "errors" is not accessed (reportUnusedVariable)
+  /workspace/personal-rag-copilot/src/ui/settings.py:111:21 - error: Argument type is partially unknown
+    Argument corresponds to parameter "fn" in function "change"
+    Argument type is "(v: Unknown, s: Unknown) -> Tuple[Dict[str, Any], str]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:111:28 - error: Type of parameter "v" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:111:31 - error: Type of parameter "s" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:111:59 - error: Argument type is unknown
+    Argument corresponds to parameter "settings" in function "update_field" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:116:21 - error: Argument type is partially unknown
+    Argument corresponds to parameter "fn" in function "change"
+    Argument type is "(v: Unknown, s: Unknown) -> Tuple[Dict[str, Any], str]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:116:28 - error: Type of parameter "v" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:116:31 - error: Type of parameter "s" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:116:59 - error: Argument type is unknown
+    Argument corresponds to parameter "settings" in function "update_field" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:138:58 - error: "_latencies" is protected and used outside of the class in which it is declared (reportPrivateUsage)
+  /workspace/personal-rag-copilot/src/ui/settings.py:139:57 - error: "_latencies" is protected and used outside of the class in which it is declared (reportPrivateUsage)
+  /workspace/personal-rag-copilot/src/ui/settings.py:181:21 - error: Argument type is partially unknown
+    Argument corresponds to parameter "fn" in function "change"
+    Argument type is "(v: Unknown, s: Unknown) -> Tuple[Dict[str, Any], str]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:181:28 - error: Type of parameter "v" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:181:31 - error: Type of parameter "s" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:181:74 - error: Argument type is unknown
+    Argument corresponds to parameter "settings" in function "update_policy_field" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:186:21 - error: Argument type is partially unknown
+    Argument corresponds to parameter "fn" in function "change"
+    Argument type is "(v: Unknown, s: Unknown) -> Tuple[Dict[str, Any], str]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:186:28 - error: Type of parameter "v" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:186:31 - error: Type of parameter "s" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:186:70 - error: Argument type is unknown
+    Argument corresponds to parameter "settings" in function "update_policy_field" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:191:21 - error: Argument type is partially unknown
+    Argument corresponds to parameter "fn" in function "change"
+    Argument type is "(v: Unknown, s: Unknown) -> Tuple[Dict[str, Any], str]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:191:28 - error: Type of parameter "v" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:191:31 - error: Type of parameter "s" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:191:85 - error: Argument type is unknown
+    Argument corresponds to parameter "settings" in function "update_policy_field" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:196:21 - error: Argument type is partially unknown
+    Argument corresponds to parameter "fn" in function "change"
+    Argument type is "(v: Unknown, s: Unknown) -> Tuple[Dict[str, Any], str]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:196:28 - error: Type of parameter "v" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:196:31 - error: Type of parameter "s" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:196:78 - error: Argument type is unknown
+    Argument corresponds to parameter "settings" in function "update_policy_field" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:201:21 - error: Argument type is partially unknown
+    Argument corresponds to parameter "fn" in function "change"
+    Argument type is "(v: Unknown, s: Unknown) -> Tuple[Dict[str, Any], str]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:201:28 - error: Type of parameter "v" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:201:31 - error: Type of parameter "s" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:201:67 - error: Argument type is unknown
+    Argument corresponds to parameter "settings" in function "update_field" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:211:21 - error: Argument type is partially unknown
+    Argument corresponds to parameter "fn" in function "click"
+    Argument type is "(m: Unknown) -> Any" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:211:28 - error: Type of parameter "m" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:214:43 - error: Argument type is unknown
+    Argument corresponds to parameter "mode" in function "get_latency_trend" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/src/ui/settings.py:232:21 - error: Argument type is partially unknown
+    Argument corresponds to parameter "fn" in function "change"
+    Argument type is "(file: Unknown, settings: Dict[str, Any]) -> (tuple[Dict[str, Any], Literal[''], Any | None, Any | None] | tuple[Dict[str, Any], Literal['Invalid configuration'], Any | None, Any | None])" (reportUnknownArgumentType)
+/workspace/personal-rag-copilot/src/utils/hardware.py
+  /workspace/personal-rag-copilot/src/utils/hardware.py:15:9 - error: Type of "core" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/src/utils/hardware.py:16:27 - error: Argument type is unknown
+    Argument corresponds to parameter "o" in function "getattr" (reportUnknownArgumentType)
+/workspace/personal-rag-copilot/tests/conftest.py
+  /workspace/personal-rag-copilot/tests/conftest.py:14:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+  /workspace/personal-rag-copilot/tests/conftest.py:20:29 - error: Type of parameter "warning_message" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/conftest.py:20:29 - error: Type annotation is missing for parameter "warning_message" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/conftest.py:20:46 - error: Type of parameter "when" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/conftest.py:20:46 - error: Type annotation is missing for parameter "when" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/conftest.py:20:52 - error: Type of parameter "nodeid" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/conftest.py:20:52 - error: Type annotation is missing for parameter "nodeid" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/conftest.py:20:60 - error: Type of parameter "location" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/conftest.py:20:60 - error: Type annotation is missing for parameter "location" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/conftest.py:32:28 - error: Type of "message" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/conftest.py:32:28 - error: Argument type is unknown
+    Argument corresponds to parameter "object" in function "__new__" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/conftest.py:33:25 - error: Type of "category" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/conftest.py:33:25 - error: Type of "__name__" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/conftest.py:34:25 - error: Type of "filename" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/conftest.py:35:23 - error: Type of "lineno" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/conftest.py:42:26 - error: Type of parameter "session" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/conftest.py:42:26 - error: Type annotation is missing for parameter "session" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/conftest.py:42:35 - error: Type of parameter "exitstatus" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/conftest.py:42:35 - error: Type annotation is missing for parameter "exitstatus" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/conftest.py:48:13 - error: Type of "config" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/conftest.py:48:13 - error: Type of "rootdir" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/conftest.py:48:13 - error: Argument type is unknown
+    Argument corresponds to parameter "object" in function "__new__" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/conftest.py:85:5 - error: Type of "tr" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/conftest.py:85:10 - error: Type of "config" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/conftest.py:85:10 - error: Type of "pluginmanager" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/conftest.py:85:10 - error: Type of "get_plugin" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/conftest.py:87:9 - error: Type of "write_line" is unknown (reportUnknownMemberType)
+/workspace/personal-rag-copilot/tests/test_app.py
+  /workspace/personal-rag-copilot/tests/test_app.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+/workspace/personal-rag-copilot/tests/test_config/test_backup.py
+  /workspace/personal-rag-copilot/tests/test_config/test_backup.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+  /workspace/personal-rag-copilot/tests/test_config/test_backup.py:7:31 - error: Type of "backup_config" is partially unknown
+    Type of "backup_config" is "(path: str, backup_dir: str) -> Tuple[Path, dict[Unknown, Unknown]]" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_config/test_backup.py:7:46 - error: Type of "restore_config" is partially unknown
+    Type of "restore_config" is "(backup_path: str, target_path: str) -> Tuple[Path, dict[Unknown, Unknown]]" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_config/test_backup.py:14:18 - error: Type of "_" is partially unknown
+    Type of "_" is "dict[Unknown, Unknown]" (reportUnknownVariableType)
+/workspace/personal-rag-copilot/tests/test_config/test_runtime_config.py
+  /workspace/personal-rag-copilot/tests/test_config/test_runtime_config.py:47:18 - error: Type of parameter "cfg" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_config/test_runtime_config.py:47:18 - error: Type annotation is missing for parameter "cfg" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_config/test_runtime_config.py:48:23 - error: Argument type is unknown
+    Argument corresponds to parameter "object" in function "append" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_config/test_runtime_config.py:50:26 - error: Argument type is partially unknown
+    Argument corresponds to parameter "callback" in function "register"
+    Argument type is "(cfg: Unknown) -> None" (reportUnknownArgumentType)
+/workspace/personal-rag-copilot/tests/test_config/test_runtime_config_errors.py
+  /workspace/personal-rag-copilot/tests/test_config/test_runtime_config_errors.py:8:23 - error: Type of parameter "cfg" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_config/test_runtime_config_errors.py:8:23 - error: Type annotation is missing for parameter "cfg" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_config/test_runtime_config_errors.py:24:37 - error: Argument type is partially unknown
+    Argument corresponds to parameter "validator" in function "__init__"
+    Argument type is "(cfg: Unknown) -> tuple[Literal[False], dict[str, str]]" (reportUnknownArgumentType)
+/workspace/personal-rag-copilot/tests/test_config/test_settings.py
+  /workspace/personal-rag-copilot/tests/test_config/test_settings.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+/workspace/personal-rag-copilot/tests/test_config/test_validate.py
+  /workspace/personal-rag-copilot/tests/test_config/test_validate.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+/workspace/personal-rag-copilot/tests/test_evaluation/test_ragas_integration.py
+  /workspace/personal-rag-copilot/tests/test_evaluation/test_ragas_integration.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+/workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py
+  /workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py:8:29 - error: "_load_dashboard" is private and used outside of the module in which it is declared (reportPrivateUsage)
+  /workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py:75:27 - error: Type of parameter "start" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py:75:27 - error: Type annotation is missing for parameter "start" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py:75:34 - error: Type of parameter "end" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py:75:34 - error: Type annotation is missing for parameter "end" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py:78:52 - error: Argument type is partially unknown
+    Argument corresponds to parameter "value" in function "setattr"
+    Argument type is "(start: Unknown, end: Unknown) -> list[EvaluationResult]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py:79:5 - error: Variable "summary" is not accessed (reportUnusedVariable)
+  /workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py:79:14 - error: Variable "fig" is not accessed (reportUnusedVariable)
+  /workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py:79:19 - error: Variable "df" is not accessed (reportUnusedVariable)
+  /workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py:79:23 - error: Variable "corr" is not accessed (reportUnusedVariable)
+  /workspace/personal-rag-copilot/tests/test_evaluation/test_recommendations.py:79:29 - error: Variable "alerts" is not accessed (reportUnusedVariable)
+/workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:24:22 - error: Type of parameter "vectors" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:24:22 - error: Type annotation is missing for parameter "vectors" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:24:31 - error: Type of parameter "namespace" is partially unknown
+    Parameter type is "Unknown | None" (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:24:31 - error: Type annotation is missing for parameter "namespace" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:29:42 - error: Argument type is unknown
+    Argument corresponds to parameter "object" in function "append" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:31:9 - error: Return type, "dict[str, list[Unknown]]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:31:21 - error: Type of parameter "vector" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:31:21 - error: Type annotation is missing for parameter "vector" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:31:29 - error: Type of parameter "top_k" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:31:29 - error: Type annotation is missing for parameter "top_k" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:31:36 - error: Type of parameter "include_metadata" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:31:36 - error: Type annotation is missing for parameter "include_metadata" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:31:54 - error: Type of parameter "namespace" is partially unknown
+    Parameter type is "Unknown | None" (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:31:54 - error: Type annotation is missing for parameter "namespace" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:36:16 - error: Return type, "dict[str, list[Unknown]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:42:19 - error: Type of parameter "api_key" is partially unknown
+    Parameter type is "Unknown | None" (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:42:19 - error: Type annotation is missing for parameter "api_key" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:42:33 - error: Type of parameter "environment" is partially unknown
+    Parameter type is "Unknown | None" (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:42:33 - error: Type annotation is missing for parameter "environment" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:45:9 - error: Return type, "list[Unknown]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:46:16 - error: Return type, "list[Unknown]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:48:27 - error: Type of parameter "name" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:48:27 - error: Type annotation is missing for parameter "name" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:48:33 - error: Type of parameter "dimension" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:48:33 - error: Type annotation is missing for parameter "dimension" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:48:44 - error: Type of parameter "metric" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:48:44 - error: Type annotation is missing for parameter "metric" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:59:29 - error: Type of parameter "name" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:60:22 - error: Type of parameter "name" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:61:31 - error: Type of parameter "name" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:74:27 - error: Type of parameter "name" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:74:27 - error: Type annotation is missing for parameter "name" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:80:21 - error: Type of parameter "api_key" is partially unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:80:35 - error: Type of parameter "environment" is partially unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:83:22 - error: Type of parameter "name" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:84:31 - error: Type of parameter "kwargs" is partially unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:85:31 - error: Type of parameter "name" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:98:21 - error: Type of parameter "api_key" is partially unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:98:35 - error: Type of parameter "environment" is partially unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:99:22 - error: Type of parameter "name" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:100:31 - error: Type of parameter "name" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:101:30 - error: Return type of lambda, "list[Unknown]", is partially unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:102:31 - error: Type of parameter "kwargs" is partially unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:103:29 - error: Type of parameter "name" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:112:9 - error: Argument type is partially unknown
+    Argument corresponds to parameter "value" in function "setattr"
+    Argument type is "(s: Unknown) -> None" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:112:16 - error: Type of parameter "s" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:112:38 - error: Argument type is unknown
+    Argument corresponds to parameter "object" in function "append" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:114:5 - error: Type of "vectors" is partially unknown
+    Type of "vectors" is "list[tuple[str, list[float], dict[Unknown, Unknown]]]" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:117:9 - error: Argument type is partially unknown
+    Argument corresponds to parameter "vectors" in function "upsert_embeddings"
+    Argument type is "list[tuple[str, list[float], dict[Unknown, Unknown]]]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:130:21 - error: Type of parameter "api_key" is partially unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:130:35 - error: Type of parameter "environment" is partially unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:131:22 - error: Type of parameter "name" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:132:31 - error: Type of parameter "name" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:133:30 - error: Return type of lambda, "list[Unknown]", is partially unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:134:31 - error: Type of parameter "kwargs" is partially unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_integrations/test_pinecone_client.py:135:29 - error: Type of parameter "name" is unknown (reportUnknownLambdaType)
+/workspace/personal-rag-copilot/tests/test_monitoring/test_auto_tuner.py
+  /workspace/personal-rag-copilot/tests/test_monitoring/test_auto_tuner.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+/workspace/personal-rag-copilot/tests/test_monitoring/test_performance.py
+  /workspace/personal-rag-copilot/tests/test_monitoring/test_performance.py:66:46 - error: Type of "approx" is partially unknown
+    Type of "approx" is "(expected: Unknown, rel: Unknown | None = None, abs: Unknown | None = None, nan_ok: bool = False) -> ApproxBase" (reportUnknownMemberType)
+/workspace/personal-rag-copilot/tests/test_monitoring/test_policy_management.py
+  /workspace/personal-rag-copilot/tests/test_monitoring/test_policy_management.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+/workspace/personal-rag-copilot/tests/test_monitoring/test_tracker_dashboard.py
+  /workspace/personal-rag-copilot/tests/test_monitoring/test_tracker_dashboard.py:39:33 - error: Type of "approx" is partially unknown
+    Type of "approx" is "(expected: Unknown, rel: Unknown | None = None, abs: Unknown | None = None, nan_ok: bool = False) -> ApproxBase" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_monitoring/test_tracker_dashboard.py:40:32 - error: Type of "approx" is partially unknown
+    Type of "approx" is "(expected: Unknown, rel: Unknown | None = None, abs: Unknown | None = None, nan_ok: bool = False) -> ApproxBase" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_monitoring/test_tracker_dashboard.py:41:46 - error: Type of "approx" is partially unknown
+    Type of "approx" is "(expected: Unknown, rel: Unknown | None = None, abs: Unknown | None = None, nan_ok: bool = False) -> ApproxBase" (reportUnknownMemberType)
+/workspace/personal-rag-copilot/tests/test_query_service.py
+  /workspace/personal-rag-copilot/tests/test_query_service.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+  /workspace/personal-rag-copilot/tests/test_query_service.py:11:9 - error: Return type, "tuple[list[Unknown], dict[Unknown, Unknown]]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_query_service.py:11:21 - error: Type of parameter "query" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_query_service.py:11:21 - error: Type annotation is missing for parameter "query" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_query_service.py:11:28 - error: Type of parameter "mode" is partially unknown
+    Parameter type is "Unknown | None" (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_query_service.py:11:28 - error: Type annotation is missing for parameter "mode" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_query_service.py:11:39 - error: Type annotation is missing for parameter "top_k" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_query_service.py:11:50 - error: Type of parameter "kwargs" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_query_service.py:11:50 - error: Type annotation is missing for parameter "kwargs" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_query_service.py:12:9 - error: Type of "last_mode" is partially unknown
+    Type of "last_mode" is "Unknown | None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_query_service.py:13:16 - error: Return type, "tuple[list[Unknown], dict[Unknown, Unknown]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_query_service.py:18:28 - error: Argument of type "StubHybrid" cannot be assigned to parameter "retriever" of type "HybridRetriever" in function "__init__"
+    "StubHybrid" is not assignable to "HybridRetriever" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_query_service.py:20:12 - error: Type of "last_mode" is partially unknown
+    Type of "last_mode" is "Unknown | None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_query_service.py:25:28 - error: Argument of type "StubHybrid" cannot be assigned to parameter "retriever" of type "HybridRetriever" in function "__init__"
+    "StubHybrid" is not assignable to "HybridRetriever" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_query_service.py:27:12 - error: Type of "last_mode" is partially unknown
+    Type of "last_mode" is "Unknown | None" (reportUnknownMemberType)
+/workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:9:5 - error: Return type, "list[dict[str, Unknown | str]]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:9:17 - error: Type of parameter "ids" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:9:17 - error: Type annotation is missing for parameter "ids" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:10:12 - error: Return type, "list[dict[str, Unknown | str]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:10:48 - error: Type of "i" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:16:21 - error: Type of parameter "query" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:16:21 - error: Type annotation is missing for parameter "query" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:16:28 - error: Type of parameter "texts" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:16:28 - error: Type annotation is missing for parameter "texts" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:29:21 - error: Type of parameter "query" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:29:21 - error: Type annotation is missing for parameter "query" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:29:28 - error: Type of parameter "texts" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:29:28 - error: Type annotation is missing for parameter "texts" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:31:25 - error: Type of "_" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:47:29 - error: Type of parameter "benchmark" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:47:29 - error: Type annotation is missing for parameter "benchmark" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:50:21 - error: Type of parameter "q" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:50:21 - error: Type annotation is missing for parameter "q" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:50:24 - error: Type of parameter "texts" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:50:24 - error: Type annotation is missing for parameter "texts" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ranking/test_reranker.py:51:25 - error: Type of "_" is unknown (reportUnknownVariableType)
+/workspace/personal-rag-copilot/tests/test_ranking/test_rrf.py
+  /workspace/personal-rag-copilot/tests/test_ranking/test_rrf.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+/workspace/personal-rag-copilot/tests/test_retrieval/conftest.py
+  /workspace/personal-rag-copilot/tests/test_retrieval/conftest.py:8:25 - error: Type of parameter "args" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/conftest.py:8:25 - error: Type annotation is missing for parameter "args" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/conftest.py:8:33 - error: Type of parameter "kwargs" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/conftest.py:8:33 - error: Type annotation is missing for parameter "kwargs" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/conftest.py:12:5 - error: Return type, "list[Unknown]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/conftest.py:12:12 - error: Type of parameter "self" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/conftest.py:12:12 - error: Type annotation is missing for parameter "self" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/conftest.py:12:19 - error: Type of parameter "args" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/conftest.py:12:19 - error: Type annotation is missing for parameter "args" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/conftest.py:12:27 - error: Type of parameter "kwargs" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/conftest.py:12:27 - error: Type annotation is missing for parameter "kwargs" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/conftest.py:13:12 - error: Return type, "list[Unknown]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/conftest.py:16:21 - error: Cannot assign to attribute "encode" for class "type[SentenceTransformer]"
+    Attribute "encode" is unknown (reportAttributeAccessIssue)
+  /workspace/personal-rag-copilot/tests/test_retrieval/conftest.py:17:6 - error: Cannot assign to attribute "SentenceTransformer" for class "ModuleType"
+    Attribute "SentenceTransformer" is unknown (reportAttributeAccessIssue)
+/workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:20:50 - error: Type of parameter "vectors" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:20:50 - error: Type annotation is missing for parameter "vectors" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:21:9 - error: Type of "vectors" is partially unknown
+    Type of "vectors" is "list[Unknown]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:21:9 - error: Type of "extend" is partially unknown
+    Type of "extend" is "(iterable: Iterable[Unknown], /) -> None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:21:29 - error: Argument type is unknown
+    Argument corresponds to parameter "iterable" in function "extend" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:25:40 - error: Type of parameter "mock_model" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:25:40 - error: Type annotation is missing for parameter "mock_model" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:33:32 - error: Argument of type "MockPineconeClient" cannot be assigned to parameter "pinecone_client" of type "PineconeClient" in function "__init__"
+    "MockPineconeClient" is not assignable to "PineconeClient" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:40:39 - error: Type of parameter "mock_model" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:40:39 - error: Type annotation is missing for parameter "mock_model" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:45:19 - error: Type of parameter "texts" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:45:19 - error: Type annotation is missing for parameter "texts" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:45:26 - error: Type of parameter "batch_size" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:45:26 - error: Type annotation is missing for parameter "batch_size" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:45:38 - error: Type of parameter "show_progress_bar" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:45:38 - error: Type annotation is missing for parameter "show_progress_bar" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:46:30 - error: Argument type is unknown
+    Argument corresponds to parameter "obj" in function "len" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:52:32 - error: Argument of type "MockPineconeClient" cannot be assigned to parameter "pinecone_client" of type "PineconeClient" in function "__init__"
+    "MockPineconeClient" is not assignable to "PineconeClient" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:58:16 - error: Type of "vectors" is partially unknown
+    Type of "vectors" is "list[Unknown]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:58:16 - error: Argument type is partially unknown
+    Argument corresponds to parameter "obj" in function "len"
+    Argument type is "list[Unknown]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:62:38 - error: Type of parameter "mock_model" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:62:38 - error: Type annotation is missing for parameter "mock_model" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:68:32 - error: Argument of type "MockPineconeClient" cannot be assigned to parameter "pinecone_client" of type "PineconeClient" in function "__init__"
+    "MockPineconeClient" is not assignable to "PineconeClient" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:70:5 - error: Type of "assert_called_with" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_dense.py:88:36 - error: Argument of type "MockPineconeClient" cannot be assigned to parameter "pinecone_client" of type "PineconeClient" in function "__init__"
+    "MockPineconeClient" is not assignable to "PineconeClient" (reportArgumentType)
+/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py:8:21 - error: Type of parameter "query" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py:8:21 - error: Type annotation is missing for parameter "query" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py:8:28 - error: Type annotation is missing for parameter "top_k" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py:13:21 - error: Type of parameter "query" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py:13:21 - error: Type annotation is missing for parameter "query" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py:13:28 - error: Type annotation is missing for parameter "top_k" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py:18:30 - error: Argument of type "StubDense" cannot be assigned to parameter "dense_retriever" of type "DenseRetriever" in function "__init__"
+    "StubDense" is not assignable to "DenseRetriever" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py:18:43 - error: Argument of type "StubLexical" cannot be assigned to parameter "lexical_retriever" of type "LexicalBM25" in function "__init__"
+    "StubLexical" is not assignable to "LexicalBM25" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py:28:30 - error: Argument of type "StubDense" cannot be assigned to parameter "dense_retriever" of type "DenseRetriever" in function "__init__"
+    "StubDense" is not assignable to "DenseRetriever" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py:28:43 - error: Argument of type "StubLexical" cannot be assigned to parameter "lexical_retriever" of type "LexicalBM25" in function "__init__"
+    "StubLexical" is not assignable to "LexicalBM25" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid.py:40:28 - error: Argument of type "StubDense" cannot be assigned to parameter "dense_retriever" of type "DenseRetriever" in function "__init__"
+    "StubDense" is not assignable to "DenseRetriever" (reportArgumentType)
+/workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:8:9 - error: Return type, "tuple[list[tuple[str, float]], dict[Unknown, Unknown]]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:8:21 - error: Type of parameter "query" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:8:21 - error: Type annotation is missing for parameter "query" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:8:28 - error: Type annotation is missing for parameter "top_k" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:9:16 - error: Return type, "tuple[list[tuple[str, float]], dict[Unknown, Unknown]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:17:9 - error: Return type, "tuple[list[tuple[str, float]], dict[Unknown, Unknown]]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:17:21 - error: Type of parameter "query" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:17:21 - error: Type annotation is missing for parameter "query" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:17:28 - error: Type annotation is missing for parameter "top_k" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:18:16 - error: Return type, "tuple[list[tuple[str, float]], dict[Unknown, Unknown]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:22:9 - error: Return type, "tuple[list[Unknown], dict[str, bool | int]]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:22:22 - error: Type of parameter "query" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:22:22 - error: Type annotation is missing for parameter "query" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:22:29 - error: Type of parameter "docs" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:22:29 - error: Type annotation is missing for parameter "docs" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:22:35 - error: Type annotation is missing for parameter "top_k" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:22:44 - error: Type annotation is missing for parameter "session_id" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:22:66 - error: Type annotation is missing for parameter "timeout" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:23:9 - error: Type of "docs" is partially unknown
+    Type of "docs" is "list[Unknown]" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:23:21 - error: Argument type is partially unknown
+    Argument corresponds to parameter "iterable" in function "__init__"
+    Argument type is "Iterator[Unknown]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:23:30 - error: Argument type is unknown
+    Argument corresponds to parameter "sequence" in function "__new__" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:24:16 - error: Return type, "tuple[list[Unknown], dict[str, bool | int]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:29:9 - error: Argument of type "StubDense" cannot be assigned to parameter "dense_retriever" of type "DenseRetriever" in function "__init__"
+    "StubDense" is not assignable to "DenseRetriever" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:30:9 - error: Argument of type "StubLexical" cannot be assigned to parameter "lexical_retriever" of type "LexicalBM25" in function "__init__"
+    "StubLexical" is not assignable to "LexicalBM25" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_hybrid_rerank.py:31:18 - error: Argument of type "StubReranker" cannot be assigned to parameter "reranker" of type "CrossEncoderReranker | None" in function "__init__"
+    Type "StubReranker" is not assignable to type "CrossEncoderReranker | None"
+      "StubReranker" is not assignable to "CrossEncoderReranker"
+      "StubReranker" is not assignable to "None" (reportArgumentType)
+/workspace/personal-rag-copilot/tests/test_retrieval/test_lexical.py
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_lexical.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+/workspace/personal-rag-copilot/tests/test_retrieval/test_query_analysis.py
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_query_analysis.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_query_analysis.py:16:50 - error: Argument of type "DummyLexical" cannot be assigned to parameter "lexical" of type "LexicalBM25" in function "analyze_query"
+    "DummyLexical" is not assignable to "LexicalBM25" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_retrieval/test_query_analysis.py:24:46 - error: Argument of type "DummyLexical" cannot be assigned to parameter "lexical" of type "LexicalBM25" in function "analyze_query"
+    "DummyLexical" is not assignable to "LexicalBM25" (reportArgumentType)
+/workspace/personal-rag-copilot/tests/test_services/test_document_service.py
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:33:10 - warning: Import "fpdf" could not be resolved from source (reportMissingModuleSource)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:38:23 - error: No parameter named "txt" (reportCallIssue)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:39:5 - error: No overloads for "output" match the provided arguments (reportCallIssue)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:39:16 - error: Argument of type "Path" cannot be assigned to parameter "name" of type "str" in function "output"
+    "Path" is not assignable to "str" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:47:14 - error: Argument of type "Path" cannot be assigned to parameter "path_or_stream" of type "str | IO[bytes]" in function "save"
+    Type "Path" is not assignable to type "str | IO[bytes]"
+      "Path" is not assignable to "str"
+      "Path" is not assignable to "IO[bytes]" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:50:48 - error: Type of parameter "mocks" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:50:48 - error: Type annotation is missing for parameter "mocks" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:51:5 - error: Type of "dense" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:51:12 - error: Type of "lexical" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:52:31 - error: Argument type is unknown
+    Argument corresponds to parameter "dense_retriever" in function "__init__" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:52:38 - error: Argument type is unknown
+    Argument corresponds to parameter "lexical_retriever" in function "__init__" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:78:43 - error: Type of parameter "mocks" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:78:43 - error: Type annotation is missing for parameter "mocks" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:79:5 - error: Type of "dense" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:79:12 - error: Type of "lexical" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:80:31 - error: Argument type is unknown
+    Argument corresponds to parameter "dense_retriever" in function "__init__" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:80:38 - error: Argument type is unknown
+    Argument corresponds to parameter "lexical_retriever" in function "__init__" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:86:12 - error: Type of "index_corpus" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:86:12 - error: Type of "call_args" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:87:12 - error: Type of "index_documents" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:87:12 - error: Type of "call_args" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:93:51 - error: Type of parameter "mocks" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:93:51 - error: Type annotation is missing for parameter "mocks" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:94:5 - error: Type of "dense" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:94:12 - error: Type of "lexical" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:95:31 - error: Argument type is unknown
+    Argument corresponds to parameter "dense_retriever" in function "__init__" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:95:38 - error: Argument type is unknown
+    Argument corresponds to parameter "lexical_retriever" in function "__init__" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:109:34 - error: Type of parameter "mocks" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:109:34 - error: Type annotation is missing for parameter "mocks" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:110:5 - error: Type of "dense" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:110:12 - error: Type of "lexical" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:111:31 - error: Argument type is unknown
+    Argument corresponds to parameter "dense_retriever" in function "__init__" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:111:38 - error: Argument type is unknown
+    Argument corresponds to parameter "lexical_retriever" in function "__init__" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:116:5 - error: Type of "update_document" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:116:5 - error: Type of "assert_called_with" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:117:5 - error: Type of "update_document" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:117:5 - error: Type of "assert_called_with" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:118:5 - error: Type of "delete_document" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:118:5 - error: Type of "assert_called_with" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:119:5 - error: Type of "delete_document" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:119:5 - error: Type of "assert_called_with" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:125:32 - error: Type of parameter "mocks" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:125:32 - error: Type annotation is missing for parameter "mocks" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:126:5 - error: Type of "dense" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:126:12 - error: Type of "lexical" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:127:31 - error: Argument type is unknown
+    Argument corresponds to parameter "dense_retriever" in function "__init__" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:127:38 - error: Argument type is unknown
+    Argument corresponds to parameter "lexical_retriever" in function "__init__" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:135:5 - error: Type of "update_document" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:135:5 - error: Type of "assert_called_with" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:136:5 - error: Type of "update_document" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:136:5 - error: Type of "assert_called_with" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:137:5 - error: Type of "delete_document" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:137:5 - error: Type of "assert_called_with" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:138:5 - error: Type of "delete_document" is unknown (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_services/test_document_service.py:138:5 - error: Type of "assert_called_with" is unknown (reportUnknownMemberType)
+/workspace/personal-rag-copilot/tests/test_services/test_index_management.py
+  /workspace/personal-rag-copilot/tests/test_services/test_index_management.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+  /workspace/personal-rag-copilot/tests/test_services/test_index_management.py:47:28 - error: Argument of type "DummyDense" cannot be assigned to parameter "dense" of type "DenseRetriever" in function "__init__"
+    "DummyDense" is not assignable to "DenseRetriever" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_services/test_index_management.py:47:42 - error: Argument of type "DummyLexical" cannot be assigned to parameter "lexical" of type "LexicalBM25" in function "__init__"
+    "DummyLexical" is not assignable to "LexicalBM25" (reportArgumentType)
+/workspace/personal-rag-copilot/tests/test_ui/test_chat.py
+  /workspace/personal-rag-copilot/tests/test_ui/test_chat.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+  /workspace/personal-rag-copilot/tests/test_ui/test_chat.py:10:5 - error: "_append_history" is private and used outside of the module in which it is declared (reportPrivateUsage)
+  /workspace/personal-rag-copilot/tests/test_ui/test_chat.py:11:5 - error: "_generate_response" is private and used outside of the module in which it is declared (reportPrivateUsage)
+  /workspace/personal-rag-copilot/tests/test_ui/test_chat.py:12:5 - error: "_sanitize" is private and used outside of the module in which it is declared (reportPrivateUsage)
+  /workspace/personal-rag-copilot/tests/test_ui/test_chat.py:41:9 - error: "chat" is possibly unbound (reportPossiblyUnboundVariable)
+  /workspace/personal-rag-copilot/tests/test_ui/test_chat.py:52:31 - error: Cannot assign to attribute "evaluate" for class "RagasEvaluator"
+    Type "(*_: Unknown, **__: Unknown) -> None" is not assignable to type "(query: str, answer: str, contexts: List[str]) -> EvaluationResult"
+      Function return type "None" is incompatible with type "EvaluationResult"
+        "None" is not assignable to "EvaluationResult" (reportAttributeAccessIssue)
+  /workspace/personal-rag-copilot/tests/test_ui/test_chat.py:52:39 - error: Type of parameter "_" is partially unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_chat.py:52:44 - error: Type of parameter "__" is partially unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_chat.py:55:25 - error: Type of parameter "query" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_chat.py:55:25 - error: Type annotation is missing for parameter "query" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_chat.py:55:32 - error: Type of parameter "mode" is partially unknown
+    Parameter type is "Unknown | None" (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_chat.py:55:32 - error: Type annotation is missing for parameter "mode" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_chat.py:55:43 - error: Type annotation is missing for parameter "top_k" (reportMissingParameterType)
+/workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py
+  /workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py:10:40 - error: "_load_dashboard" is private and used outside of the module in which it is declared (reportPrivateUsage)
+  /workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py:61:19 - error: Type of parameter "start" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py:61:19 - error: Type annotation is missing for parameter "start" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py:61:26 - error: Type of parameter "end" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py:61:26 - error: Type annotation is missing for parameter "end" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py:66:52 - error: Argument type is partially unknown
+    Argument corresponds to parameter "value" in function "setattr"
+    Argument type is "(start: Unknown, end: Unknown) -> list[EvaluationResult]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py:115:52 - error: Argument type is partially unknown
+    Argument corresponds to parameter "value" in function "setattr"
+    Argument type is "(s: Unknown, e: Unknown) -> list[EvaluationResult]" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py:115:59 - error: Type of parameter "s" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py:115:62 - error: Type of parameter "e" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py:120:18 - error: Type of parameter "key" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py:120:18 - error: Type annotation is missing for parameter "key" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py:120:23 - error: Type of parameter "default" is partially unknown
+    Parameter type is "Unknown | None" (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py:120:23 - error: Type annotation is missing for parameter "default" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py:123:25 - error: Argument type is unknown
+    Argument corresponds to parameter "key" in function "get" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py:123:30 - error: Argument type is partially unknown
+    Argument corresponds to parameter "default" in function "get"
+    Argument type is "Unknown | None" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_evaluate.py:125:48 - error: Argument type is partially unknown
+    Argument corresponds to parameter "value" in function "setattr"
+    Argument type is "(key: Unknown, default: Unknown | None = None) -> (dict[str, float] | Any)" (reportUnknownArgumentType)
+/workspace/personal-rag-copilot/tests/test_ui/test_gradio_integration.py
+  /workspace/personal-rag-copilot/tests/test_ui/test_gradio_integration.py:8:10 - error: Import "gradio.testing" could not be resolved (reportMissingImports)
+  /workspace/personal-rag-copilot/tests/test_ui/test_gradio_integration.py:8:32 - error: Type of "TestClient" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_gradio_integration.py:15:5 - error: Type of "client" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_gradio_integration.py:15:14 - error: Object of type "None" cannot be called (reportOptionalCall)
+  /workspace/personal-rag-copilot/tests/test_ui/test_gradio_integration.py:16:5 - error: Type of "result" is unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_gradio_integration.py:16:14 - error: Type of "chat" is unknown (reportUnknownMemberType)
+/workspace/personal-rag-copilot/tests/test_ui/test_ingest.py
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:23:5 - error: Type of "button_labels" is partially unknown
+    Type of "button_labels" is "set[Unknown]" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:26:13 - error: Type of "add" is partially unknown
+    Type of "add" is "(element: Unknown, /) -> None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:36:13 - error: Return type, "dict[str, list[Unknown]]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:36:35 - error: Type of parameter "ops" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:36:35 - error: Type annotation is missing for parameter "ops" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:38:20 - error: Return type, "dict[str, list[Unknown]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:40:13 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:40:35 - error: Type of parameter "doc_id" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:40:35 - error: Type annotation is missing for parameter "doc_id" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:40:43 - error: Type of parameter "content" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:40:43 - error: Type annotation is missing for parameter "content" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:40:52 - error: Type of parameter "metadata" is partially unknown
+    Parameter type is "Unknown | None" (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:40:52 - error: Type annotation is missing for parameter "metadata" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:42:20 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:44:13 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:44:35 - error: Type of parameter "doc_id" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:44:35 - error: Type annotation is missing for parameter "doc_id" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:46:20 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:48:13 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:50:20 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:56:34 - error: Type of parameter "path" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:56:34 - error: Type annotation is missing for parameter "path" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:60:13 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:60:26 - error: Type of parameter "files" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:60:26 - error: Type annotation is missing for parameter "files" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:60:33 - error: Type of parameter "progress" is partially unknown
+    Parameter type is "Unknown | None" (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:60:33 - error: Type annotation is missing for parameter "progress" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:61:36 - error: Argument type is unknown
+    Argument corresponds to parameter "iterable" in function "__init__" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:64:20 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:66:13 - error: Return type, "dict[str, list[Unknown]]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:66:35 - error: Type of parameter "ops" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:66:35 - error: Type annotation is missing for parameter "ops" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:67:20 - error: Type of "bulk_operations" is partially unknown
+    Type of "bulk_operations" is "(ops: Unknown) -> dict[str, list[Unknown]]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:67:20 - error: Return type, "dict[str, list[Unknown]]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:67:58 - error: Argument type is unknown
+    Argument corresponds to parameter "ops" in function "bulk_operations" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:69:13 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:69:35 - error: Type of parameter "doc_id" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:69:35 - error: Type annotation is missing for parameter "doc_id" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:69:43 - error: Type of parameter "content" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:69:43 - error: Type annotation is missing for parameter "content" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:69:52 - error: Type of parameter "metadata" is partially unknown
+    Parameter type is "Unknown | None" (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:69:52 - error: Type annotation is missing for parameter "metadata" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:70:20 - error: Type of "update_document" is partially unknown
+    Type of "update_document" is "(doc_id: Unknown, content: Unknown, metadata: Unknown | None = None) -> dict[Unknown, Unknown]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:70:20 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:71:17 - error: Argument type is unknown
+    Argument corresponds to parameter "doc_id" in function "update_document" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:72:17 - error: Argument type is unknown
+    Argument corresponds to parameter "content" in function "update_document" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:76:13 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:76:35 - error: Type of parameter "doc_id" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:76:35 - error: Type annotation is missing for parameter "doc_id" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:77:20 - error: Type of "delete_document" is partially unknown
+    Type of "delete_document" is "(doc_id: Unknown) -> dict[Unknown, Unknown]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:77:20 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:77:58 - error: Argument type is unknown
+    Argument corresponds to parameter "doc_id" in function "delete_document" (reportUnknownArgumentType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:79:13 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:80:20 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:86:5 - error: Type of "ingest" is partially unknown
+    Type of "ingest" is "(files: Unknown, progress: Unknown | None = None) -> dict[Unknown, Unknown]" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:86:45 - error: Type of parameter "p" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:86:48 - error: Type of parameter "m" is unknown (reportUnknownLambdaType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:86:51 - error: Type of "append" is partially unknown
+    Type of "append" is "(object: Unknown, /) -> None" (reportUnknownMemberType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:92:40 - error: "_queue_files" is private and used outside of the module in which it is declared (reportPrivateUsage)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:93:10 - error: Argument of type "list[DummyFile]" cannot be assigned to parameter "files" of type "list[File]" in function "_queue_files"
+    "DummyFile" is not assignable to "File" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:97:19 - error: "_process_all" is private and used outside of the module in which it is declared (reportPrivateUsage)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:100:19 - error: "_update_document" is private and used outside of the module in which it is declared (reportPrivateUsage)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:101:19 - error: "_delete_document" is private and used outside of the module in which it is declared (reportPrivateUsage)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:109:34 - error: Type of parameter "_path" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:109:34 - error: Type annotation is missing for parameter "_path" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:116:37 - error: "_queue_files" is private and used outside of the module in which it is declared (reportPrivateUsage)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest.py:117:10 - error: Argument of type "list[DummyFile]" cannot be assigned to parameter "files" of type "list[File]" in function "_queue_files"
+    "DummyFile" is not assignable to "File" (reportArgumentType)
+/workspace/personal-rag-copilot/tests/test_ui/test_ingest_queue.py
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest_queue.py:9:27 - error: "_queue_files" is private and used outside of the module in which it is declared (reportPrivateUsage)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest_queue.py:9:41 - error: "_process_all" is private and used outside of the module in which it is declared (reportPrivateUsage)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest_queue.py:9:55 - error: "_document_service" is private and used outside of the module in which it is declared (reportPrivateUsage)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest_queue.py:21:40 - error: Argument of type "list[DummyFile]" cannot be assigned to parameter "files" of type "list[File]" in function "_queue_files"
+    "DummyFile" is not assignable to "File" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest_queue.py:26:23 - error: Type of parameter "operations" is unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest_queue.py:26:23 - error: Type annotation is missing for parameter "operations" (reportMissingParameterType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_ingest_queue.py:37:63 - error: Argument type is partially unknown
+    Argument corresponds to parameter "value" in function "setattr"
+    Argument type is "(operations: Unknown) -> dict[str, list[dict[str, str | dict[str, str]]]]" (reportUnknownArgumentType)
+/workspace/personal-rag-copilot/tests/test_ui/test_performance_indicator.py
+  /workspace/personal-rag-copilot/tests/test_ui/test_performance_indicator.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+/workspace/personal-rag-copilot/tests/test_ui/test_ranking_controls.py
+  /workspace/personal-rag-copilot/tests/test_ui/test_ranking_controls.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+/workspace/personal-rag-copilot/tests/test_ui/test_settings_performance.py
+  /workspace/personal-rag-copilot/tests/test_ui/test_settings_performance.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+  /workspace/personal-rag-copilot/tests/test_ui/test_settings_performance.py:4:18 - error: Import "gr" is not accessed (reportUnusedImport)
+/workspace/personal-rag-copilot/tests/test_ui/test_transparency.py
+  /workspace/personal-rag-copilot/tests/test_ui/test_transparency.py:3:8 - error: Import "pytest" is not accessed (reportUnusedImport)
+  /workspace/personal-rag-copilot/tests/test_ui/test_transparency.py:18:38 - error: Argument of type "Literal['Doc1']" cannot be assigned to parameter "target" of type "Block | None" in function "__init__"
+    Type "Literal['Doc1']" is not assignable to type "Block | None"
+      "Literal['Doc1']" is not assignable to "Block"
+      "Literal['Doc1']" is not assignable to "None" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_transparency.py:49:12 - error: Argument of type "Literal['rank']" cannot be assigned to parameter "key" of type "SupportsIndex | slice[Any, Any, Any]" in function "__getitem__"
+    Type "Literal['rank']" is not assignable to type "SupportsIndex | slice[Any, Any, Any]"
+      "Literal['rank']" is incompatible with protocol "SupportsIndex"
+        "__index__" is not present
+      "Literal['rank']" is not assignable to "slice[Any, Any, Any]" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_ui/test_transparency.py:50:12 - error: Argument of type "Literal['score']" cannot be assigned to parameter "key" of type "SupportsIndex | slice[Any, Any, Any]" in function "__getitem__"
+    Type "Literal['score']" is not assignable to type "SupportsIndex | slice[Any, Any, Any]"
+      "Literal['score']" is incompatible with protocol "SupportsIndex"
+        "__index__" is not present
+      "Literal['score']" is not assignable to "slice[Any, Any, Any]" (reportArgumentType)
+/workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py
+  /workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py:10:31 - error: Type of "backup_config" is partially unknown
+    Type of "backup_config" is "(path: str, backup_dir: str) -> Tuple[Path, dict[Unknown, Unknown]]" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py:16:9 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py:17:42 - error: Type of parameter "metadata" is partially unknown
+    Parameter type is "dict[Unknown, Unknown] | None" (reportUnknownParameterType)
+  /workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py:17:52 - error: Expected type arguments for generic class "dict" (reportMissingTypeArgument)
+  /workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py:18:10 - error: Expected type arguments for generic class "dict" (reportMissingTypeArgument)
+  /workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py:19:16 - error: Return type, "dict[Unknown, Unknown]", is partially unknown (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py:48:18 - error: Type of "_" is partially unknown
+    Type of "_" is "dict[Unknown, Unknown]" (reportUnknownVariableType)
+  /workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py:54:27 - error: Argument of type "DummyDense" cannot be assigned to parameter "dense" of type "DenseRetriever" in function "__init__"
+    "DummyDense" is not assignable to "DenseRetriever" (reportArgumentType)
+  /workspace/personal-rag-copilot/tests/test_utils/test_timezone_handling.py:54:41 - error: Argument of type "DummyLexical" cannot be assigned to parameter "lexical" of type "LexicalBM25" in function "__init__"
+    "DummyLexical" is not assignable to "LexicalBM25" (reportArgumentType)
+733 errors, 1 warning, 0 informations

--- a/warnings_report.md
+++ b/warnings_report.md
@@ -1,6 +1,6 @@
 # Test Warnings Report
 
-- Generated: 2025-09-07T22:01:11Z
+- Generated: 2025-09-07T22:52:35Z
 - Pytest exit status: 0
 - Total warnings: 0
 


### PR DESCRIPTION
## Description:
Adds baseline Pyright diagnostics to track current type-checking state.

## Testing Done:
- `python -m pytest tests/ -v`
- `pyright --version`
- `pyright --outputjson`
- `pyright`

## Performance Impact:
None

## Configuration Changes:
None

## Evaluation Results:
N/A

------
https://chatgpt.com/codex/tasks/task_e_68be0c2b55b8832284520586716d5105