### PR TITLE
improve(config): refine pyright execution environment

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -2,10 +2,11 @@
   "typeCheckingMode": "standard",
   "strict": ["src/**", "app.py"],
   "include": ["src", "app.py", "tests"],
-  "exclude": ["**/.venv", "**/__pycache__", "**/node_modules", "**/.git"],
+  "exclude": ["**/.venv/**", "**/__pycache__/**", "**/node_modules/**", "**/.git/**"],
   "stubPath": "typings",
-  "venvPath": "/workspace/personal-rag-copilot",
-  "venv": ".venv",
+  "executionEnvironments": [
+    { "root": ".", "pythonVersion": "3.12", "pythonPlatform": "Linux" }
+  ],
   "reportMissingTypeStubs": "warning",
   "reportWildcardImportFromLibrary": "warning"
 }


### PR DESCRIPTION
## Description:
- refine pyright configuration to specify execution environment with Python 3.12 on Linux
- tighten exclude patterns to cover nested directories

## Testing Done:
- `black src/ tests/ app.py`
- `flake8 src/ tests/ app.py` *(fails: line-length and unused-import warnings)*
- `pyright` *(fails: 647 errors, 1 warning)*
- `python -m pytest tests/ -v`
- `ls scripts` *(scripts directory missing)*

## Performance Impact:
- none

## Configuration Changes:
- replaced virtual environment fields with an execution environment entry
- updated exclusion globs to match nested directories

## Evaluation Results:
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68be1365611c8322bd844f23f51208d4