### PR TITLE
feat(config): add pinecone index configuration

### DIFF
--- a/config/default_settings.yaml
+++ b/config/default_settings.yaml
@@ -6,6 +6,9 @@ device_preference: auto  # auto, cpu, gpu_openvino, gpu_xpu
 # Numerical precision for inference and retrieval operations
 precision: fp32          # fp32, fp16, int8
 
+pinecone_dense_index: dense-index
+pinecone_sparse_index: sparse-index
+
 evaluation_thresholds:
   faithfulness: 0.7
   relevancy: 0.7

--- a/src/config/runtime_config.py
+++ b/src/config/runtime_config.py
@@ -138,6 +138,12 @@ class ConfigManager:
                     continue
         if thresholds:
             overrides["evaluation_thresholds"] = thresholds
+        dense_index = os.getenv("PINECONE_DENSE_INDEX")
+        if dense_index:
+            overrides["pinecone_dense_index"] = dense_index
+        sparse_index = os.getenv("PINECONE_SPARSE_INDEX")
+        if sparse_index:
+            overrides["pinecone_sparse_index"] = sparse_index
         policy: Dict[str, Any] = {}
         num_fields = {
             "target_p95_ms": "PERF_TARGET_P95_MS",

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -110,6 +110,22 @@ def validate_performance_policy(
     return errors
 
 
+def validate_pinecone_indexes(
+    settings: Dict[str, Any], *, require_fields: bool = False
+) -> Dict[str, str]:
+    """Validate presence of Pinecone index settings."""
+    errors: Dict[str, str] = {}
+    for key in ["pinecone_dense_index", "pinecone_sparse_index"]:
+        value = settings.get(key)
+        if value is None or value == "":
+            if require_fields:
+                errors[key] = "missing"
+            continue
+        if not isinstance(value, str):
+            errors[key] = "not_string"
+    return errors
+
+
 def load_settings(path: str) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """Load YAML configuration from ``path``.
 
@@ -137,6 +153,7 @@ def load_default_settings() -> Dict[str, Any]:
     errors.update(validate_options(settings, require_fields=True))
     errors.update(validate_thresholds(settings, require_fields=True))
     errors.update(validate_performance_policy(settings, require_fields=True))
+    errors.update(validate_pinecone_indexes(settings, require_fields=True))
     if errors:
         raise ValueError(f"invalid default configuration: {errors}")
     return settings

--- a/src/config/validate.py
+++ b/src/config/validate.py
@@ -11,6 +11,7 @@ from .settings import (
     validate_options,
     validate_thresholds,
     validate_performance_policy,
+    validate_pinecone_indexes,
 )
 
 _logger = logging.getLogger(__name__)
@@ -51,6 +52,7 @@ def validate_settings(settings: Dict[str, Any]) -> Tuple[bool, Dict[str, str]]:
     errors.update(validate_options(settings))
     errors.update(validate_thresholds(settings))
     errors.update(validate_performance_policy(settings))
+    errors.update(validate_pinecone_indexes(settings, require_fields=True))
     return not errors, errors
 
 

--- a/tests/test_config/test_runtime_config.py
+++ b/tests/test_config/test_runtime_config.py
@@ -85,3 +85,24 @@ def test_env_overrides_and_device_detection(monkeypatch: pytest.MonkeyPatch) -> 
     assert cm.get("device_preference") == "gpu_xpu"
     assert cm.get("precision") == "fp16"
     assert cm.get("device") == "mock_device"
+
+
+def test_pinecone_index_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PINECONE_DENSE_INDEX", "env-dense")
+    monkeypatch.setenv("PINECONE_SPARSE_INDEX", "env-sparse")
+    cm = ConfigManager(
+        base_config={
+            "top_k": 1,
+            "rrf_k": 10,
+            "pinecone_dense_index": "base-dense",
+            "pinecone_sparse_index": "base-sparse",
+            "performance_policy": {
+                "target_p95_ms": 2000,
+                "auto_tune_enabled": False,
+                "max_top_k": 50,
+                "rerank_disable_threshold": 1500,
+            },
+        }
+    )
+    assert cm.get("pinecone_dense_index") == "env-dense"
+    assert cm.get("pinecone_sparse_index") == "env-sparse"

--- a/warnings_report.md
+++ b/warnings_report.md
@@ -1,6 +1,6 @@
 # Test Warnings Report
 
-- Generated: 2025-09-07T23:32:48Z
+- Generated: 2025-09-07T23:40:18Z
 - Pytest exit status: 0
 - Total warnings: 0
 


### PR DESCRIPTION
## Description:
- add `pinecone_dense_index` and `pinecone_sparse_index` defaults
- validate and load Pinecone index settings from environment variables
- cover configuration overrides with tests

## Testing Done:
- `python -m src.config.validate config/default_settings.yaml`
- `python -m pytest tests/test_config/test_runtime_config.py::test_pinecone_index_settings -v`
- `flake8 src/ tests/ app.py` *(fails: line length and unused imports across repository)*
- `pyright src/config/runtime_config.py src/config/settings.py tests/test_config/test_runtime_config.py` *(fails: unknown types in settings validations)*

## Performance Impact:
- No performance-impacting changes

## Configuration Changes:
- Adds `pinecone_dense_index` and `pinecone_sparse_index` settings with environment overrides

## Evaluation Results:
- N/A


------
https://chatgpt.com/codex/tasks/task_e_68be176ddae0832283404e2cba10aac8