### PR TITLE
feat(retrieval): add pinecone sparse retriever

### DIFF
--- a/src/integrations/pinecone_client.py
+++ b/src/integrations/pinecone_client.py
@@ -53,7 +53,10 @@ class PineconeClient:
                 return func(*args, **kwargs)
             except Exception as exc:  # pragma: no cover
                 if attempt == MAX_RETRIES - 1:
-                    self._logger.error("Operation failed after %s attempts", MAX_RETRIES)
+                    self._logger.error(
+                        "Operation failed after %s attempts",
+                        MAX_RETRIES,
+                    )
                     raise
                 self._logger.warning(
                     "Operation failed (%s/%s): %s",
@@ -155,6 +158,22 @@ class PineconeClient:
         return self._with_retries(
             index.query,
             vector=embedding,
+            top_k=top_k,
+            include_metadata=True,
+        )
+
+    def query_sparse(
+        self,
+        index_name: str,
+        sparse_vector: Dict[str, List[float]],
+        top_k: int = 5,
+    ) -> Any:
+        """Query a sparse Pinecone index using token frequencies."""
+
+        index = self.get_index(index_name)
+        return self._with_retries(
+            index.query,
+            sparse_vector=sparse_vector,
             top_k=top_k,
             include_metadata=True,
         )

--- a/src/retrieval/pinecone_sparse.py
+++ b/src/retrieval/pinecone_sparse.py
@@ -1,0 +1,44 @@
+import logging
+from collections import Counter
+from typing import Any, Dict, List, Tuple, Optional
+
+from src.integrations.pinecone_client import PineconeClient
+from src.retrieval.lexical import default_tokenizer, Tokenizer
+
+
+class PineconeSparseRetriever:
+    """Sparse retrieval using Pinecone's sparse index."""
+
+    def __init__(
+        self,
+        pinecone_client: PineconeClient,
+        index_name: str,
+        tokenizer: Optional[Tokenizer] = None,
+    ) -> None:
+        self._logger = logging.getLogger(__name__)
+        self.pinecone_client = pinecone_client
+        self.index_name = index_name
+        self.tokenizer = tokenizer or default_tokenizer
+
+    def _to_sparse_vector(self, text: str) -> Dict[str, List[float]]:
+        tokens = self.tokenizer(text)
+        counts = Counter(tokens)
+        indices = list(counts.keys())
+        values = [float(c) for c in counts.values()]
+        return {"indices": indices, "values": values}
+
+    def query(
+        self, query: str, top_k: int = 5
+    ) -> Tuple[List[Tuple[str, float]], Dict[str, Any]]:
+        """Query the sparse Pinecone index with BM25-like scoring."""
+        try:
+            sparse_vector = self._to_sparse_vector(query)
+            response = self.pinecone_client.query_sparse(
+                self.index_name, sparse_vector, top_k=top_k
+            )
+            matches = getattr(response, "matches", [])
+            results = [(m["id"], m["score"]) for m in matches]
+            return results, {"retrieved": len(results)}
+        except Exception as exc:  # pragma: no cover
+            self._logger.error("Sparse query failed: %s", exc)
+            return [], {"status": "error", "error": str(exc)}


### PR DESCRIPTION
## Description:
- add `PineconeSparseRetriever` for BM25-like sparse index queries
- extend `PineconeClient` with `query_sparse`

## Testing Done:
- `python -m black src/ tests/ app.py`
- `flake8 src/retrieval/pinecone_sparse.py src/integrations/pinecone_client.py`
- `pyright` *(fails: numerous existing type errors)*
- `pytest tests/test_retrieval/test_pinecone_sparse.py::test_sparse_query_returns_scores -q` *(fails: file not found)*

## Performance Impact:
- minimal; adds lightweight tokenization and Pinecone query wrapper

## Configuration Changes:
- none

## Evaluation Results:
- not applicable


------
https://chatgpt.com/codex/tasks/task_e_68be187fe4e883229734c932745f6cae