### PR TITLE
feat(ui): add retrieval mode toggle and badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # Changelog
 
 ## Unreleased
-- add precise typing for configuration utilities and settings UI
+- add retrieval mode toggle and SPARSE badge support

--- a/src/ui/components/transparency.py
+++ b/src/ui/components/transparency.py
@@ -144,14 +144,15 @@ class TransparencyPanel:
 
         citations = []
         for i, c in enumerate(meta.get("citations", [])):
-            label = c.get("label", str(i + 1))
+            doc_id = c.get("label", str(i + 1))
             link = c.get("link")
-            source = c.get("source")
-            entry = comp_scores.get(label, {}).get((source or "").lower(), {})
+            source = (c.get("source") or "").upper()
+            lookup = {"SPARSE": "lexical", "DENSE": "dense"}.get(source, source.lower())
+            entry = comp_scores.get(doc_id, {}).get(lookup, {})
             badge = CitationBadge(
-                label,
+                source or doc_id,
                 link,
-                source.title() if source else None,
+                source or None,
                 entry.get("rank"),
                 entry.get("score"),
             ).render()

--- a/src/ui/settings.py
+++ b/src/ui/settings.py
@@ -95,6 +95,12 @@ def settings_page() -> gr.Blocks:
 
         with gr.Tabs():
             with gr.Tab("Retrieval"):
+                retrieval_mode = gr.Dropdown(
+                    label="Retrieval Mode",
+                    choices=["hybrid", "dense", "lexical"],
+                    value=defaults.get("retrieval_mode", "hybrid"),
+                )
+                retrieval_mode_error = gr.Markdown()
                 top_k = gr.Number(
                     label="Top K",
                     value=defaults.get("top_k", 5),
@@ -106,6 +112,11 @@ def settings_page() -> gr.Blocks:
                 )
                 rrf_k_error = gr.Markdown()
 
+                retrieval_mode.change(
+                    lambda v, s: update_field("retrieval_mode", v, s),
+                    inputs=[retrieval_mode, settings_state],
+                    outputs=[settings_state, retrieval_mode_error],
+                )
                 top_k.change(
                     lambda v, s: update_field("top_k", v, s),
                     inputs=[top_k, settings_state],

--- a/tests/test_ui/test_settings_pinecone.py
+++ b/tests/test_ui/test_settings_pinecone.py
@@ -1,0 +1,12 @@
+from src.ui.settings import update_field
+from src.config.runtime_config import config_manager
+
+
+def test_toggle_hybrid_mode() -> None:
+    original = config_manager.as_dict()
+    settings = original
+    settings, _ = update_field("retrieval_mode", "lexical", settings)
+    assert config_manager.get("retrieval_mode") == "lexical"
+    settings, _ = update_field("retrieval_mode", "hybrid", settings)
+    assert config_manager.get("retrieval_mode") == "hybrid"
+    config_manager.set_runtime_overrides({})


### PR DESCRIPTION
## Description:
- allow switching retrieval mode via settings UI
- show SPARSE badge for lexical results and render mode badges

## Testing Done:
- `black --check .`
- `ruff check .`
- `pyright`
- `pytest -q -W default --maxfail=1`

## Performance Impact:
- N/A

## Configuration Changes:
- new `retrieval_mode` runtime setting

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68be367b2eb4832295854fd6f3eca422