### PR TITLE
feat(eval): log source in evaluation history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## Unreleased
 - add retrieval mode toggle and SPARSE badge support
+- log evaluation source (dense/sparse) for audit compliance

--- a/tests/test_evaluation/test_audit_source.py
+++ b/tests/test_evaluation/test_audit_source.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from src.evaluation.ragas_integration import RagasEvaluator
+
+
+def test_source_logged(tmp_path: Path) -> None:
+    hist = tmp_path / "history.jsonl"
+    evaluator = RagasEvaluator(history_path=hist)
+    with patch("src.evaluation.ragas_integration.evaluate") as mock_eval:
+        mock_eval.return_value = {
+            "faithfulness": [1.0],
+            "answer_relevancy": [1.0],
+            "context_precision": [1.0],
+        }
+        evaluator.evaluate("q", "a", ["ctx"], source="dense")
+    line = hist.read_text().strip()
+    data = json.loads(line)
+    assert data["source"] == "dense"
+    history = evaluator.load_history()
+    assert history[0].source == "dense"


### PR DESCRIPTION
## Description:
- record retrieval source for each Ragas evaluation result
- cover evaluation source logging with new unit test

## Testing Done:
- `black --check .`
- `ruff check .`
- `pyright`
- `pytest -q tests/test_evaluation/test_audit_source.py::test_source_logged`

## Performance Impact:
- none

## Configuration Changes:
- none

## Evaluation Results:
- not applicable

------
https://chatgpt.com/codex/tasks/task_e_68be3b61f500832281b2c66ea8e9e122