### PR TITLE
fix(config): handle settings validation errors

### DIFF
--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -24,6 +24,15 @@ def test_missing_file() -> None:
     assert meta["error"] == "file_not_found"
 
 
+def test_validation_error(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("top_k: not_a_number", encoding="utf-8")
+    settings, meta = load_settings(str(config_file))
+    assert settings.model_dump(exclude_none=True) == {}
+    assert meta["error"] == "validation_error"
+    assert "details" in meta
+
+
 def test_save_and_load_roundtrip(tmp_path: Path) -> None:
     data = {"top_k": 10, "rrf_k": 60}
     config_file = tmp_path / "config.yaml"


### PR DESCRIPTION
## Description:
- catch pydantic validation errors in `load_settings`
- propagate metadata errors to `load_default_settings`
- cover invalid config input in tests

## Testing Done:
- `ruff check .`
- `pyright`
- `pytest -q`

## Performance Impact:
- None

## Configuration Changes:
- None

## Evaluation Results:
- N/A


------
https://chatgpt.com/codex/tasks/task_e_68bf26faeba88322ba2fcc3d391034c9