### PR TITLE
improve(config): store typed settings

### DIFF
--- a/src/ui/settings.py
+++ b/src/ui/settings.py
@@ -8,6 +8,7 @@ import gradio as gr
 import pandas as pd
 
 from src.config import SettingsModel
+from src.config.models import PerformancePolicyModel
 from src.config.settings import load_settings, save_settings
 from src.config.validate import validate_settings
 from src.config.runtime_config import config_manager
@@ -222,7 +223,9 @@ def settings_page() -> gr.Blocks:
                 refresh_btn.click(
                     lambda m: (
                         QUERY_SERVICE.dashboard.p95_metrics(),
-                        config_manager.get("performance_policy", {}),
+                        config_manager.get(
+                            "performance_policy", PerformancePolicyModel()
+                        ).model_dump(),
                         get_latency_trend(m),
                     ),
                     inputs=mode_selector,

--- a/tests/test_config/test_runtime_config.py
+++ b/tests/test_config/test_runtime_config.py
@@ -60,9 +60,9 @@ def test_hot_reload_and_rollback() -> None:
     cm.set_runtime_overrides({"top_k": 2})
     cm.set_runtime_overrides({"performance_policy": {"target_p95_ms": 2500}})
     assert events[-1] == 2500
-    assert cm.get("performance_policy")["max_top_k"] == 50
+    assert cm.get("performance_policy").max_top_k == 50
     cm.rollback()
-    assert cm.get("performance_policy")["target_p95_ms"] == 2000
+    assert cm.get("performance_policy").target_p95_ms == 2000
     assert events[-1] == 2000
 
 

--- a/tests/test_ui/test_evaluate.py
+++ b/tests/test_ui/test_evaluate.py
@@ -9,6 +9,7 @@ import gradio as gr
 from src.evaluation.ragas_integration import EvaluationResult
 from src.ui.evaluate import EVALUATOR, _load_dashboard, evaluate_page
 from src.config.runtime_config import config_manager
+from src.config.models import EvaluationThresholdsModel
 
 
 def test_evaluate_page_has_components() -> None:
@@ -114,7 +115,9 @@ def test_alerts_use_thresholds(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(EVALUATOR, "load_history", lambda s, e: records)
 
-    thresholds = {"faithfulness": 0.7, "relevancy": 0.7, "precision": 0.7}
+    thresholds = EvaluationThresholdsModel(
+        faithfulness=0.7, relevancy=0.7, precision=0.7
+    )
     orig_get = config_manager.get
 
     def fake_get(key, default=None):
@@ -127,12 +130,8 @@ def test_alerts_use_thresholds(monkeypatch: pytest.MonkeyPatch) -> None:
     _, _, _, _, alerts, _, _, _ = _load_dashboard(None, None)
     assert "q1" in alerts and "q2" in alerts
 
-    thresholds.update(
-        {
-            "faithfulness": 0.5,
-            "relevancy": 0.5,
-            "precision": 0.5,
-        }
-    )
+    thresholds.faithfulness = 0.5
+    thresholds.relevancy = 0.5
+    thresholds.precision = 0.5
     _, _, _, _, alerts, _, _, _ = _load_dashboard(None, None)
     assert alerts == "No alerts"

--- a/tests/test_ui/test_settings_performance.py
+++ b/tests/test_ui/test_settings_performance.py
@@ -25,7 +25,7 @@ def test_manual_overrides_update_config_manager() -> None:
     original = config_manager.as_dict()
     settings = original
     settings, _ = update_policy_field("target_p95_ms", 2500, settings)
-    assert config_manager.get("performance_policy")["target_p95_ms"] == 2500
+    assert config_manager.get("performance_policy").target_p95_ms == 2500
     settings, _ = update_field("enable_rerank", True, settings)
     assert config_manager.get("enable_rerank") is True
     config_manager.set_runtime_overrides({})


### PR DESCRIPTION
## Description:
- refactor runtime config to maintain `SettingsModel` layers and typed overrides
- expose thresholds and policies via models across UI and monitoring
- adjust tests for typed configuration access

## Testing Done:
- `ruff check .`
- `pyright` *(fails: 243 errors)*
- `pytest -q`

## Performance Impact:
- no performance changes expected

## Configuration Changes:
- runtime config now stores `SettingsModel` instances

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bf27c6c5d88322b17d5f454ccb6d75