### PR TITLE
refactor(core): remove dataclasses imports

### DIFF
--- a/src/evaluation/ragas_integration.py
+++ b/src/evaluation/ragas_integration.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 
 import datetime
 import json
-from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Any, List, Optional
+
+from pydantic import BaseModel
 
 from ragas import evaluate
 from ragas.metrics import answer_relevancy, context_precision, faithfulness
 
 
-@dataclass
-class EvaluationResult:
+class EvaluationResult(BaseModel):
     """Container for a single evaluation.
 
     References: FR-RET-006, FR-EVAL-001
@@ -94,7 +94,7 @@ class RagasEvaluator:
         self.history.append(record)
         self.history_path.parent.mkdir(parents=True, exist_ok=True)
         with self.history_path.open("a", encoding="utf-8") as file:
-            file.write(json.dumps(asdict(record)) + "\n")
+            file.write(json.dumps(record.model_dump()) + "\n")
         return record
 
     def load_history(

--- a/src/evaluation/recommendations.py
+++ b/src/evaluation/recommendations.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Dict, List
+
+from pydantic import BaseModel
 
 from src.config.runtime_config import config_manager
 from src.config.models import EvaluationThresholdsModel
@@ -43,8 +44,7 @@ def generate_recommendations(metrics: Dict[str, float]) -> List[str]:
     return recs
 
 
-@dataclass
-class RecommendationRecord:
+class RecommendationRecord(BaseModel):
     """Record of a recommendation and resulting metrics."""
 
     recommendation: str
@@ -66,9 +66,9 @@ class RecommendationLogger:
     ) -> None:
         self.records.append(
             RecommendationRecord(
-                recommendation,
-                metrics_before,
-                metrics_after,
+                recommendation=recommendation,
+                before=metrics_before,
+                after=metrics_after,
             )
         )
 

--- a/src/monitoring/auto_tuner.py
+++ b/src/monitoring/auto_tuner.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 """Automatic tuning of retrieval parameters based on latency."""
 
-from dataclasses import dataclass, field
 from typing import Dict, Any
 
 from src.monitoring.performance import MetricsDashboard
@@ -10,23 +9,26 @@ from src.config.runtime_config import ConfigManager, config_manager
 from src.config.models import PerformancePolicyModel
 
 
-@dataclass
 class AutoTuner:
     """Reduce retrieval costs when latency exceeds policy thresholds."""
 
-    dashboard: MetricsDashboard
-    threshold_ms: float = 2000
-    config: ConfigManager | None = config_manager
-    auto_tune_enabled: bool = field(default=True)
+    def __init__(
+        self,
+        dashboard: MetricsDashboard,
+        threshold_ms: float = 2000,
+        config: ConfigManager | None = config_manager,
+        auto_tune_enabled: bool = True,
+    ) -> None:
+        self.dashboard = dashboard
+        self.threshold_ms = threshold_ms
+        self.config = config
+        self.auto_tune_enabled = auto_tune_enabled
 
-    def __post_init__(self) -> None:  # pragma: no cover - trivial cache
         if self.config:
             policy = self.config.get(
                 "performance_policy", PerformancePolicyModel()
             )
-            self.threshold_ms = (
-                policy.target_p95_ms or self.threshold_ms
-            )
+            self.threshold_ms = policy.target_p95_ms or self.threshold_ms
             self.auto_tune_enabled = (
                 policy.auto_tune_enabled
                 if policy.auto_tune_enabled is not None

--- a/src/ui/components/ranking_controls.py
+++ b/src/ui/components/ranking_controls.py
@@ -2,22 +2,25 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any, Dict
 
 import gradio as gr
 
 
-@dataclass
 class RankingControls:
     """Grouped sliders and toggle for ranking parameters."""
 
-    rrf_k: int = 60
-    w_dense: float = 1.0
-    w_lexical: float = 1.0
-    enable_rerank: bool = False
-
-    def __post_init__(self) -> None:
+    def __init__(
+        self,
+        rrf_k: int = 60,
+        w_dense: float = 1.0,
+        w_lexical: float = 1.0,
+        enable_rerank: bool = False,
+    ) -> None:
+        self.rrf_k = rrf_k
+        self.w_dense = w_dense
+        self.w_lexical = w_lexical
+        self.enable_rerank = enable_rerank
         self.state = gr.State(
             {
                 "rrf_k": self.rrf_k,

--- a/src/ui/components/transparency.py
+++ b/src/ui/components/transparency.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 import gradio as gr
@@ -11,15 +10,22 @@ from html import escape
 from gradio.events import EventData
 
 
-@dataclass
 class CitationBadge:
     """Simple badge representing a citation source."""
 
-    label: str
-    link: Optional[str] = None
-    source: Optional[str] = None
-    rank: Optional[int] = None
-    score: Optional[float] = None
+    def __init__(
+        self,
+        label: str,
+        link: Optional[str] = None,
+        source: Optional[str] = None,
+        rank: Optional[int] = None,
+        score: Optional[float] = None,
+    ) -> None:
+        self.label = label
+        self.link = link
+        self.source = source
+        self.rank = rank
+        self.score = score
 
     def render(self) -> str:
         """Return HTML for the badge."""
@@ -51,12 +57,12 @@ class CitationBadge:
         return self.label
 
 
-@dataclass
 class DetailsDrawer:
     """Expandable drawer to show retrieval metadata."""
 
-    content: Any = field(default_factory=dict)
-    open: bool = False
+    def __init__(self, content: Any | None = None, open: bool = False) -> None:
+        self.content = content if content is not None else {}
+        self.open = open
 
     def render(self) -> gr.Accordion:
         with gr.Accordion("Details", open=self.open) as acc:
@@ -72,12 +78,12 @@ class DetailsDrawer:
         return gr.update(value=content)
 
 
-@dataclass
 class PerformanceIndicator:
     """Display simple performance metrics such as latency and memory."""
 
-    latency_ms: float = 0.0
-    memory_mb: float = 0.0
+    def __init__(self, latency_ms: float = 0.0, memory_mb: float = 0.0) -> None:
+        self.latency_ms = latency_ms
+        self.memory_mb = memory_mb
 
     def render(self) -> gr.Markdown:
         self.md = gr.Markdown(self.format_metrics())


### PR DESCRIPTION
## Description:
- replace dataclass usage with simple classes or Pydantic models
- drop `from dataclasses import dataclass` across UI, monitoring and evaluation modules

## Testing Done:
- `ruff check .`
- `pyright` *(fails: 640 errors pre-existing)*
- `pytest -q`

## Performance Impact:
- n/a

## Configuration Changes:
- n/a

## Evaluation Results:
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68bf32b1fa708322bd653e72eebce2e3