### PR TITLE
fix(ui): send evaluation contexts and mode

### DIFF
--- a/src/ui/chat.py
+++ b/src/ui/chat.py
@@ -62,6 +62,8 @@ def _generate_response(
 
     metrics = perf.metrics()
 
+    contexts = [doc.get("text", "") for doc in results]
+
     citations = []
     for rank, doc in enumerate(results, start=1):
         raw_source = doc.get("source", "")
@@ -101,7 +103,12 @@ def _generate_response(
 
     assistant_message["content"] = assistant_message["content"].strip()
     _append_history(conversation)
-    EVALUATOR.evaluate(sanitized, assistant_message["content"], [sanitized])
+    EVALUATOR.evaluate(
+        sanitized,
+        assistant_message["content"],
+        contexts,
+        source=retrieval_meta.get("retrieval_mode", "hybrid"),
+    )
 
 
 def chat_page() -> gr.Blocks:


### PR DESCRIPTION
## Description:
- derive evaluation contexts from retrieved documents and pass retrieval mode to evaluator
- update chat tests for new evaluation signature and context fields

## Testing Done:
- `ruff check .`
- `pyright src/ui/chat.py tests/test_ui/test_chat.py`
- `pytest -q`

## Performance Impact:
- n/a

## Configuration Changes:
- n/a

## Evaluation Results:
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68bf439a74888322a469fcc4789fbb0a