### PR TITLE
fix(evaluation): centralize evaluation history path

### DIFF
--- a/src/evaluation/ragas_integration.py
+++ b/src/evaluation/ragas_integration.py
@@ -13,6 +13,9 @@ from ragas import evaluate
 from ragas.metrics import answer_relevancy, context_precision, faithfulness
 
 
+EVALUATION_HISTORY_PATH = Path("evaluations/history.jsonl")
+
+
 class EvaluationResult(BaseModel):
     """Container for a single evaluation.
 
@@ -35,7 +38,7 @@ class RagasEvaluator:
     """Compute evaluation metrics using Ragas."""
 
     def __init__(
-        self, history_path: Path | str = "evaluation_history.jsonl"
+        self, history_path: Path | str = EVALUATION_HISTORY_PATH
     ) -> None:  # noqa: E501
         self.history_path = Path(history_path)
         self.history: List[EvaluationResult] = []

--- a/src/ui/chat.py
+++ b/src/ui/chat.py
@@ -11,7 +11,10 @@ import gradio as gr  # type: ignore[import]
 from .components.transparency import TransparencyPanel
 from ..monitoring.performance import PerformanceTracker
 from .navbar import render_navbar
-from ..evaluation.ragas_integration import RagasEvaluator
+from ..evaluation.ragas_integration import (
+    EVALUATION_HISTORY_PATH,
+    RagasEvaluator,
+)
 from ..config.runtime_config import config_manager
 from src.services import get_query_service
 
@@ -19,7 +22,7 @@ from src.services import get_query_service
 QUERY_SERVICE = get_query_service()
 
 HISTORY_PATH = Path("chat_history.jsonl")
-EVALUATOR = RagasEvaluator()
+EVALUATOR = RagasEvaluator(history_path=EVALUATION_HISTORY_PATH)
 
 
 def _sanitize(text: str) -> str:

--- a/src/ui/evaluate.py
+++ b/src/ui/evaluate.py
@@ -9,13 +9,17 @@ import gradio as gr
 import pandas as pd
 import plotly.express as px
 
-from src.evaluation.ragas_integration import EvaluationResult, RagasEvaluator
+from src.evaluation.ragas_integration import (
+    EVALUATION_HISTORY_PATH,
+    EvaluationResult,
+    RagasEvaluator,
+)
 from src.evaluation.recommendations import generate_recommendations
 from src.config.models import EvaluationThresholdsModel
 from src.config.runtime_config import config_manager
 from .navbar import render_navbar
 
-EVALUATOR = RagasEvaluator()
+EVALUATOR = RagasEvaluator(history_path=EVALUATION_HISTORY_PATH)
 
 
 def _history_to_df(history: List[EvaluationResult]) -> pd.DataFrame:

--- a/tests/test_ui/test_chat.py
+++ b/tests/test_ui/test_chat.py
@@ -5,7 +5,10 @@ from pathlib import Path
 
 import gradio as gr
 
-from src.evaluation.ragas_integration import EvaluationResult
+from src.evaluation.ragas_integration import (
+    EVALUATION_HISTORY_PATH,
+    EvaluationResult,
+)
 import src.ui.chat as chat
 from src.ui.chat import (
     _append_history,
@@ -44,7 +47,6 @@ def test_generate_response_streams(tmp_path: Path) -> None:
     file_path = tmp_path / "history.jsonl"
 
     chat.HISTORY_PATH = file_path
-    original_eval_path = chat.EVALUATOR.history_path
     chat.EVALUATOR.history_path = tmp_path / "eval.jsonl"
     original_evaluate = chat.EVALUATOR.evaluate
     chat.EVALUATOR.evaluate = (
@@ -96,7 +98,7 @@ def test_generate_response_streams(tmp_path: Path) -> None:
 
     chat.QUERY_SERVICE = original_service
     chat.HISTORY_PATH = HISTORY_PATH
-    chat.EVALUATOR.history_path = original_eval_path
+    chat.EVALUATOR.history_path = EVALUATION_HISTORY_PATH
     chat.EVALUATOR.evaluate = original_evaluate
 
 
@@ -104,7 +106,6 @@ def test_sparse_badge_display(tmp_path: Path) -> None:
     file_path = tmp_path / "history.jsonl"
 
     chat.HISTORY_PATH = file_path
-    original_eval_path = chat.EVALUATOR.history_path
     chat.EVALUATOR.history_path = tmp_path / "eval.jsonl"
     original_evaluate = chat.EVALUATOR.evaluate
     chat.EVALUATOR.evaluate = (
@@ -139,7 +140,7 @@ def test_sparse_badge_display(tmp_path: Path) -> None:
 
     chat.QUERY_SERVICE = original_service
     chat.HISTORY_PATH = HISTORY_PATH
-    chat.EVALUATOR.history_path = original_eval_path
+    chat.EVALUATOR.history_path = EVALUATION_HISTORY_PATH
     chat.EVALUATOR.evaluate = original_evaluate
 
 


### PR DESCRIPTION
## Description:
- define `EVALUATION_HISTORY_PATH` constant for evaluation history storage
- use constant when constructing `RagasEvaluator` in chat and evaluation UIs
- update tests to reset evaluator history path via constant

## Testing Done:
- `ruff check .`
- `pyright`
- `pytest -q`

## Performance Impact:
- no change

## Configuration Changes:
- `EVALUATION_HISTORY_PATH` now defaults to `evaluations/history.jsonl`

## Evaluation Results:
- not applicable

------
https://chatgpt.com/codex/tasks/task_e_68bf452f9b18832288315387761929bf