### PR TITLE
fix(config): drop TypedDict metadata

### DIFF
--- a/src/config/backup.py
+++ b/src/config/backup.py
@@ -5,18 +5,9 @@ from __future__ import annotations
 import datetime
 import shutil
 from pathlib import Path
-from typing import TypedDict
 
 
-class BackupMetadata(TypedDict):
-    source: str
-
-
-class RestoreMetadata(TypedDict):
-    backup: str
-
-
-def backup_config(path: str, backup_dir: str) -> tuple[Path, BackupMetadata]:
+def backup_config(path: str, backup_dir: str) -> tuple[Path, dict[str, str]]:
     """Create a timestamped backup of ``path`` inside ``backup_dir``."""
     source = Path(path)
     dest_dir = Path(backup_dir)
@@ -27,7 +18,7 @@ def backup_config(path: str, backup_dir: str) -> tuple[Path, BackupMetadata]:
     return backup_path, {"source": str(source)}
 
 
-def restore_config(backup_path: str, target_path: str) -> tuple[Path, RestoreMetadata]:
+def restore_config(backup_path: str, target_path: str) -> tuple[Path, dict[str, str]]:
     """Restore configuration from ``backup_path`` to ``target_path"."""
     backup = Path(backup_path)
     target = Path(target_path)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import TypedDict
 
 import yaml
 from pydantic import ValidationError
@@ -25,12 +24,6 @@ EVAL_METRICS = {"faithfulness", "relevancy", "precision"}
 
 
 from .models import SettingsModel
-
-
-class Metadata(TypedDict, total=False):
-    path: str
-    error: str
-    details: str
 
 
 def validate_options(
@@ -133,7 +126,7 @@ def validate_pinecone_indexes(
     return errors
 
 
-def load_settings(path: str) -> tuple[SettingsModel, Metadata]:
+def load_settings(path: str) -> tuple[SettingsModel, dict[str, str]]:
     """Load YAML configuration from ``path``.
 
     Returns a tuple of ``(settings, metadata)``. If loading or validation fails


### PR DESCRIPTION
## Description:
- replace remaining `TypedDict` metadata structures in configuration modules with simple dictionaries to align with Pydantic settings models

## Testing Done:
- `ruff check .`
- `pyright` *(fails: 514 errors)*
- `pytest -q`

## Performance Impact:
- none

## Configuration Changes:
- none

## Evaluation Results:
- n/a


------
https://chatgpt.com/codex/tasks/task_e_68bf5ea1fb74832286902ce919999afd