### PR TITLE
fix(config): add typed metadata handling

### DIFF
--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,6 +1,6 @@
 """Configuration package."""
 
-from .settings import load_settings
+from .settings import Metadata, load_settings
 from .validate import validate_settings
 from .backup import backup_config, restore_config
 from .runtime_config import (
@@ -19,6 +19,7 @@ from .models import (
 
 __all__ = [
     "load_settings",
+    "Metadata",
     "validate_settings",
     "backup_config",
     "restore_config",

--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -12,6 +12,8 @@ def test_load_settings(tmp_path: Path) -> None:
     config_file.write_text(data, encoding="utf-8")
 
     settings, meta = load_settings(str(config_file))
+    assert isinstance(settings, SettingsModel)
+    assert isinstance(meta, dict)
     data = settings.model_dump()
     assert data["key"] == "value"
     assert data["number"] == 1
@@ -20,6 +22,7 @@ def test_load_settings(tmp_path: Path) -> None:
 
 def test_missing_file() -> None:
     settings, meta = load_settings("nonexistent.yaml")
+    assert isinstance(settings, SettingsModel)
     assert settings.model_dump(exclude_none=True) == {}
     assert meta["error"] == "file_not_found"
 
@@ -28,6 +31,7 @@ def test_validation_error(tmp_path: Path) -> None:
     config_file = tmp_path / "config.yaml"
     config_file.write_text("top_k: not_a_number", encoding="utf-8")
     settings, meta = load_settings(str(config_file))
+    assert isinstance(settings, SettingsModel)
     assert settings.model_dump(exclude_none=True) == {}
     assert meta["error"] == "validation_error"
     assert "details" in meta
@@ -39,6 +43,7 @@ def test_save_and_load_roundtrip(tmp_path: Path) -> None:
     meta = save_settings(SettingsModel.model_validate(data), str(config_file))
     assert "error" not in meta
     loaded, _ = load_settings(meta["path"])
+    assert isinstance(loaded, SettingsModel)
     assert loaded.model_dump(exclude_none=True) == data
 
 


### PR DESCRIPTION
## Description:
- parse YAML directly into `SettingsModel` and surface validation problems via typed `Metadata`
- expose `Metadata` in config package and adjust save/load helpers
- update configuration tests to expect model instances

## Testing Done:
- `ruff check .`
- `pyright`
- `pytest -q`

## Performance Impact:
- N/A

## Configuration Changes:
- `load_settings` and `save_settings` now return `Metadata` with error details

## Evaluation Results:
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68bf662f82288322851a8cc8731abfe8